### PR TITLE
E2-9: expose pp_harness.ack_run via gateway allow-list

### DIFF
--- a/docs/PORTABILITY.md
+++ b/docs/PORTABILITY.md
@@ -123,12 +123,38 @@ To regenerate after moving repos or editing the template, just re-run setup.
 
 Path resolution across the ecosystem is OS-agnostic (env override → anchor-relative
 → sibling → fail loud, with forward slashes). The one remaining OS-specific surface
-is the Claude Code **hooks**, which are authored in PowerShell (`.claude/hooks/*.ps1`)
-and registered with `pwsh -NoProfile -File "$CLAUDE_PROJECT_DIR/.claude/hooks/<name>.ps1"`.
+is the Claude Code **hooks**, which are authored in PowerShell (`*.ps1`).
 
-- The hook **commands no longer hardcode absolute paths** — every repo's hook
-  registration now uses `$CLAUDE_PROJECT_DIR`, which Claude Code injects at
-  hook-execution time. So the *path* is portable.
+Hydra and the squad packs ship their hooks as **Claude Code plugins**. For this
+repo that means the scripts live at `plugins/hydra/hooks/*.ps1` and are declared
+in `plugins/hydra/hooks/hooks.json` — *not* in `.claude/settings.json`. The
+portable path token for a plugin-shipped hook is **`${CLAUDE_PLUGIN_ROOT}`**,
+which resolves to the plugin's installation directory:
+
+```
+pwsh -NoProfile -File "${CLAUDE_PLUGIN_ROOT}/hooks/<name>.ps1"
+```
+
+`${CLAUDE_PLUGIN_ROOT}` is the documented placeholder for plugin-relative hook
+paths (Claude Code Hooks Reference § Path Placeholders,
+<https://code.claude.com/docs/en/hooks.md>). It supersedes `$CLAUDE_PROJECT_DIR`
+for hooks that a plugin owns; `$CLAUDE_PROJECT_DIR` remains correct for hooks a
+repo still registers directly in its own `.claude/settings.json`.
+
+Note this is a **host-interface** detail only — where Claude Code finds and
+launches the guard scripts. Hydra remains authoritative for workflow state,
+HITL, budgets, envelope validation, and RBAC regardless of how the hooks are
+registered.
+
+- The hook **commands no longer hardcode absolute paths** — plugin-shipped hooks
+  use `${CLAUDE_PLUGIN_ROOT}` and any remaining repo-registered hooks use
+  `$CLAUDE_PROJECT_DIR`. Both are injected by Claude Code at hook-execution
+  time, so the *path* is portable either way.
+- **Migration caveat:** when hooks move into a plugin, delete the superseded
+  registrations from `.claude/settings.json` (and from user-scope
+  `~/.claude/settings.json`). Hook definitions from all settings levels **merge
+  rather than replace** each other, so a leftover entry does not get overridden
+  — it keeps firing, and points at a script that no longer exists.
 - To **run** the PowerShell hooks on macOS/Linux you need **PowerShell 7+ (`pwsh`)**
   installed and on `PATH` (`brew install powershell` / `apt install powershell`).
   `pwsh` is itself cross-platform, so the existing `.ps1` hooks run unmodified.

--- a/hydra_core/toolshed.py
+++ b/hydra_core/toolshed.py
@@ -282,7 +282,7 @@ def _extract_tags(name: str, description: str) -> list[str]:
 # ---------- static catalogs for known servers ----------
 
 PP_HARNESS_TOOLS = [
-    "analyze_autogenesis", "agents_md_status", "apply_agents_md_patch",
+    "ack_run", "analyze_autogenesis", "agents_md_status", "apply_agents_md_patch",
     "apply_master_plan_patch", "archive_artifact", "archive_winner_and_losers",
     "artifact_validate", "audit_status", "borda_count", "browser_validation_finalize",
     "browser_validation_start", "budget_status", "completion_checklist",

--- a/tests/test_gateway_catalog_complete.py
+++ b/tests/test_gateway_catalog_complete.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from hydra_core.toolshed import build_default_shed
+import pytest
+
+from hydra_core.toolshed import PP_HARNESS_TOOLS, build_default_shed
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -33,3 +35,39 @@ def test_new_gateway_catalogs_expose_representative_tools() -> None:
     assert shed.describe("rlm_gaming", "rlmgaming.ping") is not None
     assert shed.describe("marketbliss", "mb.ping") is not None
     assert shed.describe("xenia", "xenia.ping") is not None
+
+
+def test_ack_run_is_exposed_through_the_gateway() -> None:
+    """E2-9: the pp daemon defines `ack_run` and the pp SessionStart guidance
+    points operators at it, so the gateway allow-list must expose it."""
+    assert "ack_run" in PP_HARNESS_TOOLS
+
+    shed = build_default_shed()
+    assert shed.describe("pp_harness", "ack_run") is not None
+
+
+def test_pp_harness_allowlist_covers_cached_schema_catalog() -> None:
+    """Regression guard for E2-9.
+
+    The only pp_harness schema catalog is user-scope
+    (``~/.hydra/gateway_schemas.json``, written by the gateway when it
+    introspects the daemon); it is not vendored in-repo. When it is present,
+    every tool it lists under ``pp_harness`` must be in ``PP_HARNESS_TOOLS`` so
+    a newly added daemon tool cannot silently drop out of the gateway. When it
+    is absent (CI, a fresh checkout) this check skips and the static assertion
+    in the test above still holds.
+    """
+    catalog_path = Path.home() / ".hydra" / "gateway_schemas.json"
+    if not catalog_path.is_file():
+        pytest.skip(f"no gateway schema catalog at {catalog_path}")
+
+    catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+    pp_schemas = catalog.get("pp_harness")
+    if not isinstance(pp_schemas, dict) or not pp_schemas:
+        pytest.skip("gateway schema catalog has no pp_harness section")
+
+    missing = sorted(set(pp_schemas) - set(PP_HARNESS_TOOLS))
+    assert not missing, (
+        "pp_harness tools present in the gateway schema catalog but missing "
+        f"from PP_HARNESS_TOOLS: {missing}"
+    )


### PR DESCRIPTION
## Summary

The gateway exposes pair-programmer tools only from `PP_HARNESS_TOOLS` in `hydra_core/toolshed.py`. The pp daemon defines `ack_run`, and the pp SessionStart hook tells the operator to use `pp_harness.ack_run` to dismiss a stale run, but the tool was missing from the allow-list. `mcp__hydra_gateway__pp_harness__ack_run` therefore did not exist in a Hydra session, so the guidance pointed at an unreachable tool.

## Changes

- `hydra_core/toolshed.py`: add `ack_run` to `PP_HARNESS_TOOLS` (alphabetical position).
- `tests/test_gateway_catalog_complete.py`: two regression tests.
  - `test_ack_run_is_exposed_through_the_gateway` — static assertion plus a `build_default_shed().describe("pp_harness", "ack_run")` reachability check.
  - `test_pp_harness_allowlist_covers_cached_schema_catalog` — asserts every `pp_harness` tool in the cached gateway schema catalog is allow-listed, so a future daemon tool cannot silently drop out. The catalog is user-scope only (`~/.hydra/gateway_schemas.json`), so the test skips gracefully when it is absent.

No RBAC change was needed: `squads/engineering/squad.yaml` enumerates only the tools the drive loop calls, and neither `janitor` nor `force_unlock` is declared there (`tests/test_squad_rbac.py` asserts `force_unlock` is rejected for the engineering squad).

## Tests

| Selection | Result |
|---|---|
| `test_gateway_catalog_complete.py`, `test_hydra_control_schema_parity.py`, `test_squad_rbac.py` | 25 passed |
| other toolshed-touching suites (`test_fable_audit_2`, `test_fable_audit2_phase5`, `test_fleet_campaign`, `test_micro_usage_audit`, `test_senate_integration`) | 264 passed, 1 skipped |

The catalog parity test ran unskipped against the local catalog and passed, confirming `ack_run` was the only gap.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
