### PR TITLE
E2-11: venom cross-check loads cerberus registry, fails closed when empty

### DIFF
--- a/docs/PORTABILITY.md
+++ b/docs/PORTABILITY.md
@@ -123,12 +123,38 @@ To regenerate after moving repos or editing the template, just re-run setup.
 
 Path resolution across the ecosystem is OS-agnostic (env override → anchor-relative
 → sibling → fail loud, with forward slashes). The one remaining OS-specific surface
-is the Claude Code **hooks**, which are authored in PowerShell (`.claude/hooks/*.ps1`)
-and registered with `pwsh -NoProfile -File "$CLAUDE_PROJECT_DIR/.claude/hooks/<name>.ps1"`.
+is the Claude Code **hooks**, which are authored in PowerShell (`*.ps1`).
 
-- The hook **commands no longer hardcode absolute paths** — every repo's hook
-  registration now uses `$CLAUDE_PROJECT_DIR`, which Claude Code injects at
-  hook-execution time. So the *path* is portable.
+Hydra and the squad packs ship their hooks as **Claude Code plugins**. For this
+repo that means the scripts live at `plugins/hydra/hooks/*.ps1` and are declared
+in `plugins/hydra/hooks/hooks.json` — *not* in `.claude/settings.json`. The
+portable path token for a plugin-shipped hook is **`${CLAUDE_PLUGIN_ROOT}`**,
+which resolves to the plugin's installation directory:
+
+```
+pwsh -NoProfile -File "${CLAUDE_PLUGIN_ROOT}/hooks/<name>.ps1"
+```
+
+`${CLAUDE_PLUGIN_ROOT}` is the documented placeholder for plugin-relative hook
+paths (Claude Code Hooks Reference § Path Placeholders,
+<https://code.claude.com/docs/en/hooks.md>). It supersedes `$CLAUDE_PROJECT_DIR`
+for hooks that a plugin owns; `$CLAUDE_PROJECT_DIR` remains correct for hooks a
+repo still registers directly in its own `.claude/settings.json`.
+
+Note this is a **host-interface** detail only — where Claude Code finds and
+launches the guard scripts. Hydra remains authoritative for workflow state,
+HITL, budgets, envelope validation, and RBAC regardless of how the hooks are
+registered.
+
+- The hook **commands no longer hardcode absolute paths** — plugin-shipped hooks
+  use `${CLAUDE_PLUGIN_ROOT}` and any remaining repo-registered hooks use
+  `$CLAUDE_PROJECT_DIR`. Both are injected by Claude Code at hook-execution
+  time, so the *path* is portable either way.
+- **Migration caveat:** when hooks move into a plugin, delete the superseded
+  registrations from `.claude/settings.json` (and from user-scope
+  `~/.claude/settings.json`). Hook definitions from all settings levels **merge
+  rather than replace** each other, so a leftover entry does not get overridden
+  — it keeps firing, and points at a script that no longer exists.
 - To **run** the PowerShell hooks on macOS/Linux you need **PowerShell 7+ (`pwsh`)**
   installed and on `PATH` (`brew install powershell` / `apt install powershell`).
   `pwsh` is itself cross-platform, so the existing `.ps1` hooks run unmodified.

--- a/mcp_servers/hydra_control/server.py
+++ b/mcp_servers/hydra_control/server.py
@@ -619,6 +619,37 @@ def _run_submit_host_result(workflow_id: str, run_id: str, call_key: str,
         timeout_s=_SUBMIT_TIMEOUT_S, err_label="submit", workflow_id=workflow_id)
 
 
+def _ensure_venom_registry() -> int:
+    """Populate the process-local Cerberus venom registry, returning its size.
+
+    E2-11: ``hydra.venom.cross_check`` runs ``require_cerberus_pass`` against
+    ``hydra_core.venom``'s process-local ``_REGISTRY``, which is only ever
+    filled by ``load_cerberus_venoms()`` scanning ``squads/*/cerberus.yaml``.
+    This server never called it, so every venom-class capability looked
+    unregistered and was waved through. Called once at startup and again,
+    lazily, from the handler as a guard (the MCP SDK may serve tools without
+    this module's ``main()`` having run).
+
+    Fail-soft: a load failure is logged and reported as an empty registry. The
+    handler translates "empty" into a fail-closed refusal, so a broken load can
+    never re-open the gate.
+    """
+    try:
+        from hydra_core.venom import load_cerberus_venoms, registered_venoms
+    except Exception as exc:  # noqa: BLE001 — never fatal at startup
+        logger.warning("venom registry unavailable: %s", exc)
+        return 0
+    try:
+        if not registered_venoms():
+            load_cerberus_venoms(_HYDRA_ROOT)
+    except Exception as exc:  # noqa: BLE001 — fail-soft; gate stays fail-closed
+        logger.warning("venom registry load failed from %s: %s", _HYDRA_ROOT, exc)
+    try:
+        return len(registered_venoms())
+    except Exception:  # noqa: BLE001
+        return 0
+
+
 def _tool_handlers() -> dict[str, Any]:
     def ping(args: dict[str, Any]) -> dict[str, Any]:
         return {
@@ -903,6 +934,12 @@ def _tool_handlers() -> dict[str, Any]:
             from hydra_core.venom import require_cerberus_pass, VenomUnregistered
         except Exception as imp_exc:  # noqa: BLE001
             return {"ok": False, "rationale": f"venom module unavailable: {imp_exc}"}
+        # E2-11: an empty registry means no venom is known to this process, so
+        # "unregistered" carries no information. Fail closed rather than
+        # approving every venom-class capability.
+        if _ensure_venom_registry() == 0:
+            return {"ok": False,
+                    "rationale": "venom registry not loaded — failing closed"}
         try:
             verdict = require_cerberus_pass(
                 capability, context,
@@ -915,7 +952,8 @@ def _tool_handlers() -> dict[str, Any]:
                 "rationale": "; ".join(verdict.refusal_reasons) or "cerberus refused",
             }
         except VenomUnregistered:
-            # Capability not in registry → not a known venom; treat as pass.
+            # Registry is non-empty (checked above) and the capability is absent
+            # from it → genuinely not a venom-class action; treat as pass.
             return {"ok": True, "rationale": "capability not in venom registry — not a venom-class action"}
         except Exception as exc:  # noqa: BLE001 — transport-shaped error → ok=false
             logger.exception("venom_cross_check: unexpected error")
@@ -1720,5 +1758,15 @@ def _serve_bare() -> None:
 
 
 def main() -> None:
+    # E2-11: prime the Cerberus venom registry before serving any tool, so
+    # hydra.venom.cross_check gates against the same capability set that
+    # `hydra doctor` reports instead of an empty dict.
+    _venom_count = _ensure_venom_registry()
+    if _venom_count:
+        logger.info("Cerberus venom registry loaded: %d capabilities", _venom_count)
+    else:
+        logger.warning(
+            "Cerberus venom registry empty (root=%s) — hydra.venom.cross_check "
+            "will fail closed", _HYDRA_ROOT)
     if not _serve_with_mcp_sdk():
         _serve_bare()

--- a/tests/test_venom_registry_fail_closed.py
+++ b/tests/test_venom_registry_fail_closed.py
@@ -1,0 +1,78 @@
+"""E2-11: `hydra.venom.cross_check` must gate against a populated registry.
+
+`hydra_core.venom` keeps a process-local `_REGISTRY` that only
+`load_cerberus_venoms()` fills, by scanning `squads/*/cerberus.yaml`. The
+hydra_control MCP server never called it, so every venom-class capability
+raised `VenomUnregistered` and was translated into `ok=True` — the governance
+gate approved everything, including `shell.destructive`.
+
+These tests pin the two halves of the fix:
+  * an empty registry fails closed (no registry, no verdict);
+  * a loaded registry actually refuses a destructive shell command, and still
+    passes capabilities that are genuinely not venom-class.
+
+Offline: no MCP transport, no subprocess, no network.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mcp_servers.hydra_control import server as control_server
+from hydra_core.venom import clear_registry, registered_venoms
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture()
+def clean_registry():
+    clear_registry()
+    yield
+    clear_registry()
+
+
+def _cross_check(args: dict) -> dict:
+    return control_server._tool_handlers()["hydra.venom.cross_check"](args)
+
+
+def test_empty_registry_fails_closed(clean_registry, tmp_path, monkeypatch):
+    """No cerberus.yaml reachable → registry stays empty → refuse."""
+    # A root with no `squads/` directory: load_cerberus_venoms() returns [].
+    monkeypatch.setattr(control_server, "_HYDRA_ROOT", tmp_path)
+    out = _cross_check({"capability": "shell.destructive",
+                        "context": {"command": "rm -rf /"}})
+    assert out["ok"] is False, out
+    assert out["rationale"] == "venom registry not loaded — failing closed"
+    assert registered_venoms() == []
+
+
+def test_loaded_registry_refuses_destructive_shell(clean_registry, monkeypatch):
+    """With the repo's cerberus.yaml loaded, a recursive delete is refused."""
+    monkeypatch.setattr(control_server, "_HYDRA_ROOT", REPO_ROOT)
+    out = _cross_check({"capability": "shell.destructive",
+                        "context": {"command": "rm -rf /"}})
+    assert out["ok"] is False, out
+    # It must be refused by Cerberus, not waved through as unknown.
+    assert "not in venom registry" not in out["rationale"]
+    assert "refusal pattern" in out["rationale"], out
+    # The lazy load populated the same set `hydra doctor` reports.
+    names = {c.name for c in registered_venoms()}
+    assert {"shell.destructive", "git.force_push", "deploy.production"} <= names
+
+
+def test_unregistered_capability_still_passes(clean_registry, monkeypatch):
+    """A non-venom capability passes — but only because the registry is real."""
+    monkeypatch.setattr(control_server, "_HYDRA_ROOT", REPO_ROOT)
+    out = _cross_check({"capability": "totally.not.a.venom.e2e11"})
+    assert out["ok"] is True, out
+    assert "not in venom registry" in out["rationale"]
+    assert registered_venoms(), "registry must be non-empty for the pass to mean anything"
+
+
+def test_ensure_venom_registry_is_idempotent(clean_registry, monkeypatch):
+    monkeypatch.setattr(control_server, "_HYDRA_ROOT", REPO_ROOT)
+    first = control_server._ensure_venom_registry()
+    second = control_server._ensure_venom_registry()
+    assert first > 0
+    assert first == second, "re-priming must not duplicate registrations"


### PR DESCRIPTION
## Problem

`hydra.venom.cross_check` ran `require_cerberus_pass` against `hydra_core.venom`'s process-local `_REGISTRY`. That dict is only ever populated by `load_cerberus_venoms()` scanning `squads/*/cerberus.yaml`, and the hydra_control MCP server never called it. Every venom-class capability therefore raised `VenomUnregistered`, which the handler translated into `{"ok": true, "rationale": "capability not in venom registry — not a venom-class action"}`.

AgentSmith's `HydraBridge.venomCrossCheck` depends on this endpoint, so the cross-system venom gate approved everything, `shell.destructive` included. Severity S1, governance gate fails open.

## Fix

- New `_ensure_venom_registry()` in `mcp_servers/hydra_control/server.py` primes the registry from `<HYDRA_ROOT>` and returns its size. Fail-soft: an import or load failure is logged, never raised.
- Called at server startup in `main()`, and lazily inside `venom_cross_check` as a guard, because the MCP SDK path can serve tools without `main()` having primed anything.
- An empty registry now fails closed: `{"ok": false, "rationale": "venom registry not loaded — failing closed"}`.
- A non-empty registry keeps the existing behaviour: a capability genuinely absent from the registry still passes with the not-a-venom rationale.

## Tests

New `tests/test_venom_registry_fail_closed.py` covers four cases: empty registry fails closed, a loaded registry refuses `shell.destructive` with a recursive-delete context on the capability's own refusal pattern, an unregistered capability still passes against a real registry, and re-priming is idempotent.

| Run | Result |
| --- | --- |
| `tests/test_venom*.py` + `test_hydra_control_schema_parity.py` + `test_fable_audit_2.py` + `test_fable_audit2_phase3.py` + new file | 171 passed |
| Full suite in the worktree | 1681 passed, 4 skipped, 2 failed |

The two failures are `test_native_pack_dispatch.py::test_active_source_packs_are_host_attended_native_plugins` and `test_claude_native_configuration.py::test_operator_skills_use_canonical_namespace_without_project_duplicates`. Both are environmental: the five `marketing-*` squad symlinks into the MarketBliss checkout are not materialised in the git worktree. Both tests pass in the main checkout on the same code.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
