### PR TITLE
E2-3: eights-drain reports dead-lettered entries and can replay the dead-letter dir

### DIFF
--- a/hydra_core/cli.py
+++ b/hydra_core/cli.py
@@ -186,7 +186,9 @@ def _cmd_doctor(args) -> int:
         _spool_warn_thresh = int(
             os.environ.get("HYDRA_EIGHTS_SPOOL_WARN", "100")
         )
-        _spool_depth = PendingSpool().count()
+        _spool_root, _dead_root = _resolve_eights_spool_roots()
+        _spool = PendingSpool(root=_spool_root, dead_letter_root=_dead_root)
+        _spool_depth = _spool.count()
         if _spool_depth > _spool_warn_thresh:
             print(
                 f"WARN: eights spool depth={_spool_depth} exceeds "
@@ -196,6 +198,16 @@ def _cmd_doctor(args) -> int:
         else:
             print(f"OK:   eights spool  depth={_spool_depth} "
                   f"(threshold={_spool_warn_thresh})")
+        # E2-3: dead letters are records that were never delivered. Depth > 0
+        # is always operator-actionable, independent of the pending depth.
+        _dead_depth = _spool.dead_letter_count()
+        if _dead_depth > 0:
+            print(
+                f"WARN: eights dead-letter depth={_dead_depth} — "
+                "run `hydra eights-drain --replay-dead-letter`"
+            )
+        else:
+            print(f"OK:   eights dead-letter  depth={_dead_depth}")
     except Exception as _spool_exc:
         print(f"WARN: eights spool check — {_spool_exc}")
 
@@ -3200,6 +3212,24 @@ def _interpolate(template: str, values: dict[str, str]) -> str:
     return result
 
 
+def _resolve_eights_spool_roots() -> tuple[Path, Path]:
+    """Resolve (spool_root, dead_letter_root), honouring the env overrides.
+
+    ``HYDRA_EIGHTS_SPOOL`` / ``HYDRA_EIGHTS_DEAD_LETTER`` let tests (and an
+    operator inspecting a copied spool) point the drain + doctor checks at a
+    scratch directory instead of ``~/.hydra/eights-pending``.
+    """
+    from .eights.pending_spool import DEFAULT_SPOOL_ROOT, DEFAULT_DEAD_LETTER_ROOT
+
+    spool_root = Path(
+        os.environ.get("HYDRA_EIGHTS_SPOOL") or DEFAULT_SPOOL_ROOT
+    )
+    dead_root = Path(
+        os.environ.get("HYDRA_EIGHTS_DEAD_LETTER") or DEFAULT_DEAD_LETTER_ROOT
+    )
+    return spool_root, dead_root
+
+
 def _cmd_eights_drain(args) -> int:
     """Drain the eights-pending spool in a bounded batch.
 
@@ -3207,21 +3237,30 @@ def _cmd_eights_drain(args) -> int:
     via the live MCPStdioDispatcher.  Also removes stale .partial staging
     files older than 1 hour (these are crash residue from interrupted writes).
 
-    Prints JSON: {drained, failed, remaining, partial_removed, spool_root}.
+    Prints JSON: {drained, failed, skipped, dead_lettered, dead_letter_depth,
+    remaining, partial_removed, spool_root, dead_letter_root}.
     ``drained`` = successfully re-sent; ``failed`` = attempted but daemon
-    rejected; ``remaining`` = still on disk after this run.
+    rejected; ``skipped`` = corrupt / concurrently-removed / TTL-expired;
+    ``dead_lettered`` = moved to the dead-letter dir on THIS run;
+    ``dead_letter_depth`` = total entries sitting in the dead-letter dir.
+
+    E2-3: entries older than --max-age-hours are dead-lettered WITHOUT a
+    replay attempt.  That used to be invisible, so an eights outage longer
+    than the 24h default silently converted the whole backlog into
+    unreplayable dead letters.  A WARN now goes to stderr whenever an entry
+    is dead-lettered for age, and `--replay-dead-letter` re-queues them.
 
     If the eights daemon is not reachable the replay attempts all fail; spool
     entries remain in place for the next run (fail-soft, never destructive).
     """
     import time as _time
-    from .eights.pending_spool import PendingSpool, DEFAULT_SPOOL_ROOT
+    from .eights.pending_spool import PendingSpool
 
     limit = int(getattr(args, "limit", 500))
+    max_age_hours = float(getattr(args, "max_age_hours", 24.0))
+    replay_dead_letter = bool(getattr(args, "replay_dead_letter", False))
     project = Path(args.project) if args.project else Path.cwd()
-    spool_root = Path(
-        os.environ.get("HYDRA_EIGHTS_SPOOL") or DEFAULT_SPOOL_ROOT
-    )
+    spool_root, dead_root = _resolve_eights_spool_roots()
 
     # Remove stale .partial files (crash residue from interrupted spool writes).
     partial_removed = 0
@@ -3235,9 +3274,21 @@ def _cmd_eights_drain(args) -> int:
             except OSError:
                 pass
 
-    spool = PendingSpool(root=spool_root)
+    spool = PendingSpool(root=spool_root, dead_letter_root=dead_root)
+
+    # E2-3: --replay-dead-letter moves dead letters back into the pending
+    # spool (attempts reset) and drains THAT pass with the age check off —
+    # otherwise every re-queued entry would immediately expire again.
+    requeued = 0
+    if replay_dead_letter:
+        requeued = spool.requeue_dead_letters(limit=limit)
+        max_age_hours = 0.0
+
     drained = 0
     failed = 0
+    skipped = 0
+    dead_lettered = 0
+    dead_lettered_expired = 0
     drain_error: str | None = None
 
     try:
@@ -3245,22 +3296,46 @@ def _cmd_eights_drain(args) -> int:
         from .eights.attestation import EightsAttestor
         dispatcher = MCPStdioDispatcher(project)
         attestor = EightsAttestor(dispatcher=dispatcher, spool=spool)
-        summary = attestor.replay_pending(max_replays=limit)
+        summary = attestor.replay_pending(
+            max_replays=limit, max_age_hours=max_age_hours
+        )
         drained = summary.get("sent", 0)
         failed = summary.get("failed", 0)
+        skipped = summary.get("skipped", 0)
+        dead_lettered = summary.get("dead_lettered", 0)
+        dead_lettered_expired = summary.get("dead_lettered_expired", 0)
     except Exception as exc:  # noqa: BLE001 — dispatcher not available → partial drain report
         drain_error = f"{type(exc).__name__}: {exc}"
 
     remaining = spool.count()
+    dead_letter_depth = spool.dead_letter_count()
     out: dict = {
         "drained": drained,
         "failed": failed,
+        "skipped": skipped,
+        "dead_lettered": dead_lettered,
+        "dead_letter_depth": dead_letter_depth,
         "remaining": remaining,
         "partial_removed": partial_removed,
         "spool_root": str(spool_root),
+        "dead_letter_root": str(dead_root),
     }
+    if replay_dead_letter:
+        out["requeued_from_dead_letter"] = requeued
     if drain_error is not None:
         out["error"] = drain_error
+
+    if dead_lettered_expired > 0:
+        print(
+            f"WARN: {dead_lettered_expired} spool entr"
+            f"{'y' if dead_lettered_expired == 1 else 'ies'} dead-lettered for "
+            f"age (older than --max-age-hours={max_age_hours}). They were NOT "
+            "replayed. Recover them with "
+            "`hydra eights-drain --replay-dead-letter`, or raise "
+            "--max-age-hours before the next drain.",
+            file=sys.stderr,
+        )
+
     print(json.dumps(out, indent=2))
     return 0
 
@@ -3468,7 +3543,8 @@ def main(argv: list[str] | None = None) -> int:
             "Drain the eights-pending spool in a bounded batch. "
             "Re-issues spooled calls to the eights daemon and removes stale "
             ".partial files older than 1 hour. "
-            "Prints JSON: {drained, failed, remaining}."
+            "Prints JSON: {drained, failed, skipped, dead_lettered, "
+            "dead_letter_depth, remaining}."
         ),
     )
     ed.add_argument(
@@ -3480,6 +3556,29 @@ def main(argv: list[str] | None = None) -> int:
             "Maximum number of spool entries to attempt in this run "
             "(default 500). Remaining entries stay in the spool for the next "
             "call."
+        ),
+    )
+    ed.add_argument(
+        "--max-age-hours",
+        dest="max_age_hours",
+        type=float,
+        default=24.0,
+        metavar="H",
+        help=(
+            "Dead-letter spool entries older than H hours WITHOUT attempting "
+            "a replay (default 24, kept for backwards compatibility; 0 "
+            "disables the age check entirely). Entries dead-lettered for age "
+            "emit a WARN on stderr — recover them with --replay-dead-letter."
+        ),
+    )
+    ed.add_argument(
+        "--replay-dead-letter",
+        dest="replay_dead_letter",
+        action="store_true",
+        help=(
+            "Move up to --limit entries from the dead-letter directory back "
+            "into the pending spool (attempts reset to 0) and drain them with "
+            "the age check disabled for that pass."
         ),
     )
 

--- a/hydra_core/eights/attestation.py
+++ b/hydra_core/eights/attestation.py
@@ -323,11 +323,18 @@ class EightsAttestor:
 
         Called by `node_intake` at the start of every workflow so the spool
         naturally drains the next time eights is healthy. Returns the same
-        ``{sent, failed, skipped}`` summary as `PendingSpool.replay` so
+        ``{sent, failed, skipped, dead_lettered, dead_lettered_expired}``
+        summary as `PendingSpool.replay` so
         callers can emit a trace event.
         """
         if not self.enabled or self.dispatcher is None:
-            return {"sent": 0, "failed": 0, "skipped": 0}
+            return {
+                "sent": 0,
+                "failed": 0,
+                "skipped": 0,
+                "dead_lettered": 0,
+                "dead_lettered_expired": 0,
+            }
 
         def _send(spooled_call: SpooledCall) -> Any:
             args = {
@@ -349,7 +356,13 @@ class EightsAttestor:
                 max_age_hours=max_age_hours,
             )
         except Exception:  # noqa: BLE001
-            return {"sent": 0, "failed": 0, "skipped": 0}
+            return {
+                "sent": 0,
+                "failed": 0,
+                "skipped": 0,
+                "dead_lettered": 0,
+                "dead_lettered_expired": 0,
+            }
 
     def replay_pending_async(
         self,

--- a/hydra_core/eights/pending_spool.py
+++ b/hydra_core/eights/pending_spool.py
@@ -182,14 +182,34 @@ class PendingSpool:
         entries that exceed ``max_attempts`` are moved to the dead-letter
         directory instead of retrying forever.
 
-        Returns a summary dict: ``{"sent": N, "failed": M, "skipped": K}``.
+        Returns a summary dict::
+
+            {"sent": N, "failed": M, "skipped": K,
+             "dead_lettered": D, "dead_lettered_expired": E}
+
         ``skipped`` counts files that were corrupt or already deleted by
         a concurrent replay, plus entries dead-lettered without a replay
         attempt because they expired their TTL.
+
+        ``dead_lettered`` counts every entry moved to the dead-letter
+        directory during THIS run — both TTL expiries and entries that
+        exhausted ``max_attempts``. ``dead_lettered_expired`` is the TTL
+        subset, so an operator can tell "the backlog aged out" (fixable by
+        raising ``--max-age-hours`` / replaying the dead-letter dir) from
+        "the daemon keeps rejecting these". E2-3: these moves used to be
+        invisible — an outage longer than the TTL silently converted the
+        whole backlog into unreplayable dead letters.
         """
         sent = failed = skipped = 0
+        dead_lettered = dead_lettered_expired = 0
         if not self.root.is_dir():
-            return {"sent": sent, "failed": failed, "skipped": skipped}
+            return {
+                "sent": sent,
+                "failed": failed,
+                "skipped": skipped,
+                "dead_lettered": dead_lettered,
+                "dead_lettered_expired": dead_lettered_expired,
+            }
 
         replayed = 0
         for path in self._iter_pending_files():
@@ -212,6 +232,8 @@ class PendingSpool:
                     skipped += 1
                     continue
                 skipped += 1
+                dead_lettered += 1
+                dead_lettered_expired += 1
                 continue
             if max_replays is not None and replayed >= max_replays:
                 break
@@ -220,18 +242,66 @@ class PendingSpool:
                 result = send_fn(sc)
             except Exception:  # noqa: BLE001 — leave on disk for next replay
                 failed += 1
-                self._record_failure(path, sc, max_attempts=max_attempts)
+                if self._record_failure(path, sc, max_attempts=max_attempts):
+                    dead_lettered += 1
                 continue
             if not result:
                 failed += 1
-                self._record_failure(path, sc, max_attempts=max_attempts)
+                if self._record_failure(path, sc, max_attempts=max_attempts):
+                    dead_lettered += 1
                 continue
             try:
                 path.unlink()
                 sent += 1
             except FileNotFoundError:
                 skipped += 1
-        return {"sent": sent, "failed": failed, "skipped": skipped}
+        return {
+            "sent": sent,
+            "failed": failed,
+            "skipped": skipped,
+            "dead_lettered": dead_lettered,
+            "dead_lettered_expired": dead_lettered_expired,
+        }
+
+    def dead_letter_count(self) -> int:
+        """How many entries sit in the dead-letter dir. 0 when it doesn't exist."""
+        if not self.dead_letter_root.is_dir():
+            return 0
+        return sum(
+            1 for p in self.dead_letter_root.iterdir() if p.suffix == ".json"
+        )
+
+    def requeue_dead_letters(self, *, limit: int | None = None) -> int:
+        """Move up to ``limit`` dead-letter entries back into the pending spool.
+
+        ``attempts`` is reset to 0 on the way back so a re-queued entry gets a
+        full retry budget. Returns the number of entries actually re-queued.
+        Corrupt dead letters are left in place for inspection (fail-soft).
+        """
+        if not self.dead_letter_root.is_dir():
+            return 0
+        self.root.mkdir(parents=True, exist_ok=True)
+        requeued = 0
+        for path in sorted(
+            p for p in self.dead_letter_root.iterdir() if p.suffix == ".json"
+        ):
+            if limit is not None and requeued >= limit:
+                break
+            try:
+                sc = SpooledCall.from_json(path.read_text(encoding="utf-8"))
+            except Exception:  # noqa: BLE001 — leave corrupt files for the operator
+                continue
+            sc.attempts = 0
+            target = self.root / path.name
+            if target.exists():
+                target = self.root / f"{sc.id}-{uuid.uuid4().hex}.json"
+            try:
+                self._write_call(path, sc)
+                os.replace(path, target)
+            except OSError:
+                continue
+            requeued += 1
+        return requeued
 
     # --- internals --------------------------------------------------------
 
@@ -241,13 +311,15 @@ class PendingSpool:
             return iter(())
         return iter(sorted(p for p in self.root.iterdir() if p.suffix == ".json"))
 
-    def _record_failure(self, path: Path, sc: SpooledCall, *, max_attempts: int) -> None:
+    def _record_failure(self, path: Path, sc: SpooledCall, *, max_attempts: int) -> bool:
+        """Persist the incremented attempt count. Returns True if dead-lettered."""
         sc.attempts += 1
         if sc.attempts > max_attempts:
             self._write_call(path, sc)
             self._dead_letter(path, sc)
-            return
+            return True
         self._write_call(path, sc)
+        return False
 
     def _write_call(self, path: Path, sc: SpooledCall) -> None:
         partial_path = path.with_suffix(f"{path.suffix}.partial")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1004,3 +1004,143 @@ def test_attended_squad_path_completes_charges_once_no_redispatch(
     assert p3.get("already_charged") is True, (
         "duplicate submit must report already_charged to prevent double-billing"
     )
+
+
+# --- eights-drain / dead-letter reporting (E2-3) -----------------------------
+#
+# Finding E2-3: `eights-drain` printed only {drained, failed, remaining,
+# partial_removed}, so a 24h+ eights outage moved the whole backlog into the
+# dead-letter dir with zero operator-visible signal. These tests pin the
+# reporting contract and the recovery path.
+
+class _StubEightsDispatcher:
+    """Stands in for MCPStdioDispatcher — every eights call succeeds."""
+
+    def __init__(self, *_a, **_kw):
+        self.calls = []
+
+    def call_mcp(self, server, tool, args, **_kw):
+        self.calls.append((server, tool, args))
+        return {"status": "done", "result": {"ok": True}}
+
+
+def _spool_env(monkeypatch, tmp_path):
+    """Point the drain + doctor spool checks at scratch dirs, never ~/.hydra."""
+    pending = tmp_path / "pending"
+    dead = tmp_path / "dead"
+    monkeypatch.setenv("HYDRA_EIGHTS_SPOOL", str(pending))
+    monkeypatch.setenv("HYDRA_EIGHTS_DEAD_LETTER", str(dead))
+    return pending, dead
+
+
+def _write_spooled(path, *, call_id, age_hours=0.0, attempts=0):
+    from datetime import datetime, timedelta, timezone
+
+    from hydra_core.eights.pending_spool import SpooledCall
+
+    call = SpooledCall(
+        id=call_id,
+        tool="eights.evolution.propose",
+        args={"slug": call_id},
+        spooled_at=(
+            datetime.now(timezone.utc) - timedelta(hours=age_hours)
+        ).isoformat(),
+        attempts=attempts,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(call.to_json(), encoding="utf-8")
+
+
+def test_eights_drain_reports_dead_lettered_and_warns_on_age(
+    tmp_path, monkeypatch, capsys
+):
+    pending, dead = _spool_env(monkeypatch, tmp_path)
+    _write_spooled(pending / "aged.json", call_id="aged", age_hours=72.0)
+    monkeypatch.setattr(
+        "hydra_core.dispatcher.MCPStdioDispatcher", _StubEightsDispatcher
+    )
+
+    rc = _run(["eights-drain"], project_root=tmp_path)
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert rc == 0
+    assert payload["drained"] == 0
+    assert payload["skipped"] == 1
+    assert payload["dead_lettered"] == 1
+    assert payload["dead_letter_depth"] == 1
+    assert payload["remaining"] == 0
+    assert payload["dead_letter_root"] == str(dead)
+    # The operator MUST be told the backlog aged out, and how to recover it.
+    assert "WARN" in captured.err
+    assert "--replay-dead-letter" in captured.err
+
+
+def test_eights_drain_max_age_hours_zero_drains_aged_backlog(
+    tmp_path, monkeypatch, capsys
+):
+    pending, _dead = _spool_env(monkeypatch, tmp_path)
+    _write_spooled(pending / "aged.json", call_id="aged", age_hours=72.0)
+    monkeypatch.setattr(
+        "hydra_core.dispatcher.MCPStdioDispatcher", _StubEightsDispatcher
+    )
+
+    rc = _run(["eights-drain", "--max-age-hours", "0"], project_root=tmp_path)
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert rc == 0
+    assert payload["drained"] == 1
+    assert payload["dead_lettered"] == 0
+    assert payload["dead_letter_depth"] == 0
+    assert "WARN" not in captured.err
+
+
+def test_eights_drain_replay_dead_letter_requeues_and_drains(
+    tmp_path, monkeypatch, capsys
+):
+    _pending, dead = _spool_env(monkeypatch, tmp_path)
+    for idx in range(3):
+        _write_spooled(
+            dead / f"dl-{idx}.json",
+            call_id=f"dl-{idx}",
+            age_hours=500.0,
+            attempts=6,
+        )
+    monkeypatch.setattr(
+        "hydra_core.dispatcher.MCPStdioDispatcher", _StubEightsDispatcher
+    )
+
+    rc = _run(
+        ["eights-drain", "--replay-dead-letter", "--limit", "2"],
+        project_root=tmp_path,
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["requeued_from_dead_letter"] == 2
+    # Re-queued entries drain even though they are far older than the TTL.
+    assert payload["drained"] == 2
+    assert payload["dead_lettered"] == 0
+    assert payload["remaining"] == 0
+    assert payload["dead_letter_depth"] == 1
+
+
+def test_doctor_warns_on_eights_dead_letter_depth(tmp_path, monkeypatch, capsys):
+    _pending, dead = _spool_env(monkeypatch, tmp_path)
+    _write_spooled(dead / "dl-0.json", call_id="dl-0", age_hours=500.0)
+
+    _run(["doctor"], project_root=REPO_ROOT)
+    out = capsys.readouterr().out
+
+    assert "WARN: eights dead-letter depth=1" in out
+    assert "--replay-dead-letter" in out
+
+
+def test_doctor_reports_clean_eights_dead_letter_depth(tmp_path, monkeypatch, capsys):
+    _spool_env(monkeypatch, tmp_path)
+
+    _run(["doctor"], project_root=REPO_ROOT)
+    out = capsys.readouterr().out
+
+    assert "OK:   eights dead-letter  depth=0" in out

--- a/tests/test_eights_replay_queue.py
+++ b/tests/test_eights_replay_queue.py
@@ -96,7 +96,13 @@ def test_replay_drains_on_success_deletes_files(tmp_path: Path) -> None:
         return {"status": "done"}
 
     summary = spool.replay(send)
-    assert summary == {"sent": 2, "failed": 0, "skipped": 0}
+    assert summary == {
+        "sent": 2,
+        "failed": 0,
+        "skipped": 0,
+        "dead_lettered": 0,
+        "dead_lettered_expired": 0,
+    }
     assert spool.count() == 0
     # Both calls reached the sender
     assert {a["slug"] for _, a in delivered} == {"a", "b"}
@@ -152,7 +158,13 @@ def test_replay_skips_corrupt_files_silently(tmp_path: Path) -> None:
 def test_replay_empty_spool_returns_zero_summary(tmp_path: Path) -> None:
     spool = PendingSpool(root=tmp_path)
     summary = spool.replay(lambda _call: {"status": "done"})
-    assert summary == {"sent": 0, "failed": 0, "skipped": 0}
+    assert summary == {
+        "sent": 0,
+        "failed": 0,
+        "skipped": 0,
+        "dead_lettered": 0,
+        "dead_lettered_expired": 0,
+    }
 
 
 def test_replay_respects_max_replays(tmp_path: Path) -> None:
@@ -168,7 +180,13 @@ def test_replay_respects_max_replays(tmp_path: Path) -> None:
         return {"status": "done"}
 
     summary = spool.replay(send, max_replays=1)
-    assert summary == {"sent": 1, "failed": 0, "skipped": 0}
+    assert summary == {
+        "sent": 1,
+        "failed": 0,
+        "skipped": 0,
+        "dead_lettered": 0,
+        "dead_lettered_expired": 0,
+    }
     assert len(delivered) == 1
     assert spool.count() == 2
 
@@ -188,9 +206,17 @@ def test_replay_dead_letters_expired_entries(tmp_path: Path) -> None:
     sent: list[str] = []
     summary = spool.replay(lambda call: sent.append(call.id) or {"status": "done"})
 
-    assert summary == {"sent": 0, "failed": 0, "skipped": 1}
+    # E2-3: the move is reported, not just counted as an opaque "skipped".
+    assert summary == {
+        "sent": 0,
+        "failed": 0,
+        "skipped": 1,
+        "dead_lettered": 1,
+        "dead_lettered_expired": 1,
+    }
     assert sent == []
     assert spool.count() == 0
+    assert spool.dead_letter_count() == 1
     assert (dead / "expired-entry.json").exists()
 
 
@@ -209,10 +235,90 @@ def test_replay_dead_letters_after_max_attempts(tmp_path: Path) -> None:
 
     summary = spool.replay(lambda _call: None, max_attempts=5)
 
-    assert summary == {"sent": 0, "failed": 1, "skipped": 0}
+    # E2-3: an attempts-exhausted move is dead_lettered but NOT expired.
+    assert summary == {
+        "sent": 0,
+        "failed": 1,
+        "skipped": 0,
+        "dead_lettered": 1,
+        "dead_lettered_expired": 0,
+    }
     assert spool.count() == 0
+    assert spool.dead_letter_count() == 1
     dead_payload = json.loads((dead / "too-many-attempts.json").read_text("utf-8"))
     assert dead_payload["attempts"] == 6
+
+
+def test_replay_reports_zero_dead_lettered_on_clean_drain(tmp_path: Path) -> None:
+    spool = PendingSpool(root=tmp_path / "pending", dead_letter_root=tmp_path / "dead")
+    spool.spool(tool="eights.evolution.propose", args={"slug": "a"})
+
+    summary = spool.replay(lambda _call: {"status": "done"})
+
+    assert summary["sent"] == 1
+    assert summary["dead_lettered"] == 0
+    assert summary["dead_lettered_expired"] == 0
+    assert spool.dead_letter_count() == 0
+
+
+def test_dead_letter_count_zero_when_dir_absent(tmp_path: Path) -> None:
+    spool = PendingSpool(
+        root=tmp_path / "pending", dead_letter_root=tmp_path / "never-created"
+    )
+    assert spool.dead_letter_count() == 0
+
+
+def test_max_age_hours_zero_disables_expiry(tmp_path: Path) -> None:
+    """E2-3: an operator can drain an aged backlog instead of losing it."""
+    dead = tmp_path / "dead"
+    spool = PendingSpool(root=tmp_path / "pending", dead_letter_root=dead)
+    _write_spooled_call(
+        spool.root / "old.json",
+        SpooledCall(
+            id="old",
+            tool="eights.evolution.propose",
+            args={"slug": "stale"},
+            spooled_at=(datetime.now(timezone.utc) - timedelta(hours=400)).isoformat(),
+        ),
+    )
+
+    summary = spool.replay(lambda _call: {"status": "done"}, max_age_hours=0)
+
+    assert summary["sent"] == 1
+    assert summary["dead_lettered"] == 0
+    assert spool.dead_letter_count() == 0
+
+
+def test_requeue_dead_letters_resets_attempts_and_moves_files(tmp_path: Path) -> None:
+    dead = tmp_path / "dead"
+    spool = PendingSpool(root=tmp_path / "pending", dead_letter_root=dead)
+    for idx in range(3):
+        _write_spooled_call(
+            dead / f"dl-{idx}.json",
+            SpooledCall(
+                id=f"dl-{idx}",
+                tool="eights.evolution.propose",
+                args={"slug": f"s{idx}"},
+                spooled_at=(
+                    datetime.now(timezone.utc) - timedelta(hours=99)
+                ).isoformat(),
+                attempts=6,
+            ),
+        )
+
+    requeued = spool.requeue_dead_letters(limit=2)
+
+    assert requeued == 2
+    assert spool.count() == 2
+    assert spool.dead_letter_count() == 1
+    assert all(call.attempts == 0 for call in spool.list_pending())
+
+
+def test_requeue_dead_letters_noop_when_dir_absent(tmp_path: Path) -> None:
+    spool = PendingSpool(
+        root=tmp_path / "pending", dead_letter_root=tmp_path / "never-created"
+    )
+    assert spool.requeue_dead_letters() == 0
 
 
 # ----- EightsAttestor integration tests -----
@@ -273,7 +379,13 @@ def test_attestor_replays_when_daemon_recovers(tmp_path: Path) -> None:
     up_dispatcher = _UpDispatcher()
     up = EightsAttestor(dispatcher=up_dispatcher, workflow_id="wf-B", spool=spool)
     summary = up.replay_pending()
-    assert summary == {"sent": 2, "failed": 0, "skipped": 0}
+    assert summary == {
+        "sent": 2,
+        "failed": 0,
+        "skipped": 0,
+        "dead_lettered": 0,
+        "dead_lettered_expired": 0,
+    }
     assert spool.count() == 0
     delivered_tools = sorted(t for _, t, _ in up_dispatcher.calls)
     assert delivered_tools == [
@@ -289,7 +401,13 @@ def test_attestor_replay_noop_when_disabled(tmp_path: Path) -> None:
     spool.spool(tool="eights.evolution.propose", args={"slug": "x"})
     attestor = EightsAttestor(dispatcher=None, enabled=False, spool=spool)
     summary = attestor.replay_pending()
-    assert summary == {"sent": 0, "failed": 0, "skipped": 0}
+    assert summary == {
+        "sent": 0,
+        "failed": 0,
+        "skipped": 0,
+        "dead_lettered": 0,
+        "dead_lettered_expired": 0,
+    }
     # Spool is preserved for when the daemon is later enabled
     assert spool.count() == 1
 
@@ -331,5 +449,11 @@ def test_attestor_replay_drops_advisory_constitution_entries(tmp_path: Path) -> 
         spool=spool,
     )
     summary = attestor.replay_pending()
-    assert summary == {"sent": 1, "failed": 0, "skipped": 0}
+    assert summary == {
+        "sent": 1,
+        "failed": 0,
+        "skipped": 0,
+        "dead_lettered": 0,
+        "dead_lettered_expired": 0,
+    }
     assert spool.count() == 0


### PR DESCRIPTION
Fixes finding E2-3 (S2): a TheEights outage longer than the 24h spool TTL converted the whole backlog into unreplayable dead letters with no operator-visible signal.

## Changes

- `PendingSpool.replay()` returns `dead_lettered` and `dead_lettered_expired` alongside `sent`/`failed`/`skipped`. Both TTL expiries and attempts-exhausted moves are counted; the expired subset is broken out so an operator can tell "the backlog aged out" from "the daemon keeps rejecting these". Existing `skipped` semantics are unchanged.
- New `PendingSpool.dead_letter_count()` and `PendingSpool.requeue_dead_letters(limit=...)` (moves dead letters back to the pending spool with `attempts` reset to 0).
- `hydra eights-drain` prints `skipped`, `dead_lettered`, `dead_letter_depth` and `dead_letter_root`. New `--max-age-hours` (default 24, so behavior is unchanged by default; `0` disables the age check) and `--replay-dead-letter [--limit N]`, which re-queues dead letters and drains that pass with the age check off. A WARN on stderr names the recovery flag whenever entries are dead-lettered for age.
- `hydra doctor` prints the dead-letter depth next to the spool depth and WARNs when it is non-zero.
- Drain and doctor now share `_resolve_eights_spool_roots()`, which honors `HYDRA_EIGHTS_SPOOL` and the new `HYDRA_EIGHTS_DEAD_LETTER` so tests never touch `~/.hydra/eights-pending`.

## Tests

Nine new tests plus updates to the existing exact-summary assertions in `tests/test_eights_replay_queue.py`.

- Targeted: `python -m pytest tests -q -k "spool or eights_drain or doctor"` → 34 passed, 1659 deselected.
- Full suite: `python -m pytest -q` → 1687 passed, 4 skipped, 2 failed.

The 2 failures are pre-existing and unrelated (plugin-pack namespace / source-pack checks). Verified by stashing this branch's changes and re-running those two tests on the base tree, where they fail identically.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
