### PR TITLE
E2-18: bash write-guard honours cd before resolving relative targets

### DIFF
--- a/plugins/hydra/hooks/hydra-block-bash-writes.ps1
+++ b/plugins/hydra/hooks/hydra-block-bash-writes.ps1
@@ -18,6 +18,18 @@
 #   - Shell heredoc (<<WORD) redirected into a blocked-extension file
 #   - PowerShell here-string (@'...'@ or @"..."@) piped to Set-Content/Out-File
 #
+# EFFECTIVE-CWD RULE (E2-18) — a relative destination is resolved against the
+# cwd the command has actually reached, not blindly against the payload's
+# session cwd. The command string is scanned for `cd` / `pushd` /
+# `Set-Location` directory tokens (quoted or bare, separated by `&&`, `;`,
+# `||`, or newline); the LAST such directory BEFORE the write idiom wins, and
+# a relative `cd` composes onto the previous effective cwd (starting from
+# $json.cwd). Without this, `cd <worktree> && echo x >> tests/p.py` resolved to
+# <projectRoot>\tests\p.py and was BLOCKED while the Edit tool on the very same
+# file was ALLOWED by hydra-block-direct-write.ps1 — the two guards disagreed.
+# An unresolvable `cd` target (variable/`-`) leaves the effective cwd unchanged,
+# which keeps the resolution inside the project root: fail CLOSED.
+#
 # RESIDUAL LIMITS — this is a guardrail, not a sandbox:
 #   - Obfuscated writes (variable indirection, eval, base64 payloads,
 #     pipes to write-capable sub-processes) can evade detection.
@@ -139,16 +151,55 @@ if ($_bwProjRootNorm) {
     [void]$_bwWtRoots.Add("$_bwProjRootNorm\.harness\worktrees")
 }
 
+# --- E2-18: effective cwd derived from cd/pushd/Set-Location in the command ---
+# Test-BlockedDest used to join a relative destination with $_bwCwd (the
+# payload's session cwd), ignoring any directory change earlier in the SAME
+# command. Build an ordered table of (end-offset -> effective cwd) so each
+# write idiom resolves against the directory in force at its own position.
+$_bwCdPat = '(?i)(?:^|[;&|\n]|\bthen\b|\bdo\b)\s*(?:cd|pushd|Set-Location|sl)\s+(?:-\w+\s+)*(?:"([^"]+)"|''([^'']+)''|([^\s;&|]+))'
+$_bwCdPoints = New-Object System.Collections.Generic.List[object]
+if ($_bwCwd) {
+    $_bwEff = $_bwCwd
+    foreach ($_cdm in [regex]::Matches($cmd, $_bwCdPat)) {
+        $_cdDir = $null
+        foreach ($_gi in 1, 2, 3) {
+            if ($_cdm.Groups[$_gi].Success) { $_cdDir = $_cdm.Groups[$_gi].Value; break }
+        }
+        if (-not $_cdDir) { continue }
+        $_cdDir = $_cdDir.Replace('/', '\')
+        # Unresolvable targets (shell/PS variable expansion, `cd -`, `~`): leave
+        # the effective cwd unchanged. That keeps resolution anchored where it
+        # already was rather than optimistically relocating it — fail CLOSED.
+        if ($_cdDir -eq '-' -or $_cdDir -eq '~' -or
+            $_cdDir.Contains('$') -or $_cdDir.Contains('%') -or $_cdDir.Contains('`')) { continue }
+        try {
+            if ([System.IO.Path]::IsPathRooted($_cdDir)) { $_bwEff = $_cdDir }
+            else { $_bwEff = (Join-Path $_bwEff $_cdDir) }
+            $_bwEff = [System.IO.Path]::GetFullPath($_bwEff)
+        } catch { continue }
+        [void]$_bwCdPoints.Add([pscustomobject]@{ Index = $_cdm.Index + $_cdm.Length; Cwd = $_bwEff })
+    }
+}
+
+function _bwEffCwdAt([int]$atIndex) {
+    $eff = $_bwCwd
+    foreach ($p in $_bwCdPoints) {
+        if ($p.Index -le $atIndex) { $eff = $p.Cwd } else { break }
+    }
+    return $eff
+}
+
 function Test-BlockedDest {
-    param([string]$dest)
+    param([string]$dest, [int]$atIndex = [int]::MaxValue)
     if (-not $dest) { return $false }
     $raw = $dest.Trim('"''').Replace('/', '\')
     $norm = $raw.ToLowerInvariant()
 
+    $_effCwd = _bwEffCwdAt $atIndex
     $absNorm = $norm
     try {
-        if ($_bwCwd -and -not [System.IO.Path]::IsPathRooted($raw)) {
-            $absNorm = (Join-Path $_bwCwd $raw).Replace('/', '\').ToLowerInvariant()
+        if ($_effCwd -and -not [System.IO.Path]::IsPathRooted($raw)) {
+            $absNorm = ([System.IO.Path]::GetFullPath((Join-Path $_effCwd $raw))).Replace('/', '\').ToLowerInvariant()
         }
     } catch { $absNorm = $norm }
 
@@ -177,7 +228,7 @@ $reason  = ''
 if (-not $matched) {
     $hits = [regex]::Matches($cmd, '>{1,2}\s*[''"]?([^\s''";|&<>]+)')
     foreach ($hit in $hits) {
-        if (Test-BlockedDest $hit.Groups[1].Value) {
+        if (Test-BlockedDest $hit.Groups[1].Value $hit.Index) {
             $matched = $true
             $reason = "output redirection to '$($hit.Groups[1].Value)'"
             break
@@ -190,7 +241,7 @@ if (-not $matched) {
 if (-not $matched) {
     $hits = [regex]::Matches($cmd, '\btee\s+(?:-[ai]\s+)*[''"]?([^\s''";|&<>\-][^\s''";|&<>]*)')
     foreach ($hit in $hits) {
-        if (Test-BlockedDest $hit.Groups[1].Value) {
+        if (Test-BlockedDest $hit.Groups[1].Value $hit.Index) {
             $matched = $true
             $reason = "tee to '$($hit.Groups[1].Value)'"
             break
@@ -205,7 +256,7 @@ if (-not $matched) {
     $hits = [regex]::Matches($cmd,
         '\b(?:cp|mv|copy|move)\b\s+\S.*?\s+([''"]?[^\s''";|&<>]+[''"]?)(?=\s*(?:$|[;&|]))')
     foreach ($hit in $hits) {
-        if (Test-BlockedDest $hit.Groups[1].Value) {
+        if (Test-BlockedDest $hit.Groups[1].Value $hit.Index) {
             $matched = $true
             $reason = "cp/mv/copy/move to '$($hit.Groups[1].Value)'"
             break
@@ -241,7 +292,7 @@ if (-not $matched) {
     $plMatches = [regex]::Matches($cmd,
         "\bPath\s*\(\s*[`"']([^`"']+)[`"']\s*\)\s*\.\s*write_(?:text|bytes)\b")
     foreach ($pm in $plMatches) {
-        if (Test-BlockedDest $pm.Groups[1].Value) {
+        if (Test-BlockedDest $pm.Groups[1].Value $pm.Index) {
             $matched = $true
             $reason = "pathlib.Path.write_text/write_bytes to '$($pm.Groups[1].Value)'"
             break
@@ -283,7 +334,7 @@ if (-not $matched) {
         $nextIsPathValue = $false
         foreach ($tok in $tokens) {
             if ($nextIsPathValue) {
-                if (Test-BlockedDest $tok) {
+                if (Test-BlockedDest $tok $m.Index) {
                     $matched = $true
                     $reason = "Set-Content/Out-File to '$tok'"
                     break
@@ -293,7 +344,7 @@ if (-not $matched) {
                 # Flag with inline value (-Path:foo.py) or flag expecting next token
                 $inline = ($tok -replace '^-(?:Path|FilePath|LiteralPath):', '')
                 if ($inline -and ($inline -ne $tok)) {
-                    if (Test-BlockedDest $inline) {
+                    if (Test-BlockedDest $inline $m.Index) {
                         $matched = $true
                         $reason = "Set-Content/Out-File to '$inline'"
                         break
@@ -303,7 +354,7 @@ if (-not $matched) {
                 }
             } elseif ($tok -notmatch '^-') {
                 # Positional argument (not a flag name or flag value)
-                if (Test-BlockedDest $tok) {
+                if (Test-BlockedDest $tok $m.Index) {
                     $matched = $true
                     $reason = "Set-Content/Out-File to '$tok'"
                     break
@@ -319,7 +370,7 @@ if (-not $matched) {
 if (-not $matched) {
     $hits = [regex]::Matches($cmd, '<<[''"]?\w+[''"]?[^;|&\n]*?>{1,2}\s*[''"]?([^\s''";|&<>]+)')
     foreach ($hit in $hits) {
-        if (Test-BlockedDest $hit.Groups[1].Value) {
+        if (Test-BlockedDest $hit.Groups[1].Value $hit.Index) {
             $matched = $true
             $reason = "heredoc into '$($hit.Groups[1].Value)'"
             break

--- a/plugins/hydra/hooks/hydra-block-direct-write.ps1
+++ b/plugins/hydra/hooks/hydra-block-direct-write.ps1
@@ -16,6 +16,14 @@
 #          stage is generating, so the deterministic codegen path is never blocked.
 #   EXEMPT the pair-programmer repo itself (working there with code is legal).
 #
+# LOCKSTEP WITH hydra-block-bash-writes.ps1 — the two guards must reach the same
+# verdict for the same file. Write/Edit payloads carry an already-absolute
+# file_path, so nothing to resolve here; the Bash hook receives a command string
+# and therefore additionally honours `cd` / `pushd` / `Set-Location` in that
+# command when resolving a RELATIVE destination (E2-18). Only the Bash hook
+# needs that code; this note exists so the pair stays in sync. The worktree-root
+# precedence block below is the other half of the lockstep.
+#
 # Kill-switch: set HYDRA_ENFORCE_ROUTING to anything but '1' to disable.
 
 $ErrorActionPreference = 'SilentlyContinue'

--- a/tests/test_e2_18_bash_hook_cd_resolution.py
+++ b/tests/test_e2_18_bash_hook_cd_resolution.py
@@ -1,0 +1,262 @@
+"""E2-18 — `hydra-block-bash-writes.ps1` must honour `cd` before resolving a
+relative write destination.
+
+The bash write-guard resolved a relative redirection/heredoc target against the
+payload's session cwd (`$json.cwd`) and ignored any `cd` / `pushd` /
+`Set-Location` earlier in the SAME command. Inside a fix worktree,
+
+    cd <.hydra-worktrees\\Hydra\\fix-X> && echo x >> tests/probe.py
+
+therefore resolved to `<projectRoot>\\tests\\probe.py` — under the project root,
+outside every worktree root — and was BLOCKED, while `hydra-block-direct-write.ps1`
+ALLOWED the Edit tool on that very same file. The two guards that must stay in
+lockstep disagreed.
+
+These tests pin the effective-cwd rule: the LAST `cd`-style directory before the
+write idiom wins, relative `cd` targets compose onto the previous effective cwd,
+and every pre-existing block stays blocked.
+
+Pwsh tests are gated on `pwsh`/`powershell` presence (skipif absent).
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HYDRA_ROOT = Path(__file__).resolve().parents[1]
+HOOKS_DIR = HYDRA_ROOT / "plugins" / "hydra" / "hooks"
+HOOK = "hydra-block-bash-writes.ps1"
+
+_PWSH = shutil.which("pwsh") or shutil.which("powershell")
+
+pytestmark = pytest.mark.skipif(
+    _PWSH is None, reason="pwsh/powershell not on PATH"
+)
+
+
+def _run_bash_hook(command: str, *, cwd: Path | None, project_dir: Path,
+                   worktree_root: Path | None = None) -> subprocess.CompletedProcess:
+    payload: dict = {"tool_name": "Bash", "tool_input": {"command": command}}
+    if cwd is not None:
+        payload["cwd"] = str(cwd)
+    env = {**os.environ}
+    env["HYDRA_ENFORCE_ROUTING"] = "1"
+    env["CLAUDE_PROJECT_DIR"] = str(project_dir)
+    env.pop("HYDRA_PP_STAGE_ACTIVE", None)
+    if worktree_root is not None:
+        env["HYDRA_WORKTREE_ROOT"] = str(worktree_root)
+    else:
+        env.pop("HYDRA_WORKTREE_ROOT", None)
+    return subprocess.run(
+        [_PWSH, "-NoProfile", "-File", str(HOOKS_DIR / HOOK)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+@pytest.fixture()
+def fake_tree(tmp_path: Path):
+    """A project root plus a sibling `.hydra-worktrees` root, mirroring the real
+    relocated layout (`<AIAPP_BASE>\\.hydra-worktrees\\<repo>\\<branch>`)."""
+    project_dir = tmp_path / "Hydra"
+    (project_dir / "tests").mkdir(parents=True)
+    wt_root = tmp_path / ".hydra-worktrees"
+    worktree = wt_root / "Hydra" / "fix-E2-18"
+    (worktree / "tests").mkdir(parents=True)
+    return project_dir, wt_root, worktree
+
+
+def test_cd_into_worktree_allows_relative_redirect(fake_tree):
+    """(1) `cd <worktree> && echo a >> tests/p.py` resolves under the worktree
+    root and is ALLOWED — the exact command the Edit hook already permits."""
+    project_dir, wt_root, worktree = fake_tree
+    result = _run_bash_hook(
+        f'cd {worktree} && echo a >> tests/p.py',
+        cwd=project_dir,
+        project_dir=project_dir,
+        worktree_root=wt_root,
+    )
+    assert result.returncode == 0, (
+        "cd into a worktree root must anchor the relative destination there; "
+        f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+
+
+def test_no_cd_relative_redirect_at_project_root_still_blocks(fake_tree):
+    """(2) The same redirection WITHOUT a `cd` resolves under the project root
+    and stays BLOCKED — the fix must not weaken the default."""
+    project_dir, wt_root, _worktree = fake_tree
+    result = _run_bash_hook(
+        "echo a >> tests/p.py",
+        cwd=project_dir,
+        project_dir=project_dir,
+        worktree_root=wt_root,
+    )
+    assert result.returncode == 2, (
+        "a relative write under the project root must stay blocked; "
+        f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "BLOCKED" in result.stderr
+
+
+def test_quoted_cd_path_with_spaces_allows_heredoc(fake_tree):
+    """(3) A QUOTED `cd` target containing spaces is parsed, and the heredoc
+    write that follows resolves under the worktree root — ALLOWED."""
+    project_dir, wt_root, _worktree = fake_tree
+    spaced = wt_root / "Hydra" / "fix with space"
+    spaced.mkdir(parents=True)
+    result = _run_bash_hook(
+        f'cd "{spaced}" && cat > rel.ts <<EOF\nconst a = 1;\nEOF',
+        cwd=project_dir,
+        project_dir=project_dir,
+        worktree_root=wt_root,
+    )
+    assert result.returncode == 0, (
+        "a quoted cd path with spaces must be honoured; "
+        f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+
+
+def test_relative_cd_from_project_root_still_blocks(fake_tree):
+    """(4) A RELATIVE `cd` composes onto the payload cwd — `cd tests` from the
+    project root lands inside the project root and stays BLOCKED."""
+    project_dir, wt_root, _worktree = fake_tree
+    result = _run_bash_hook(
+        "cd tests && echo a >> p.py",
+        cwd=project_dir,
+        project_dir=project_dir,
+        worktree_root=wt_root,
+    )
+    assert result.returncode == 2, (
+        "a relative cd inside the project root must not escape the guard; "
+        f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "BLOCKED" in result.stderr
+
+
+def test_last_cd_before_the_write_wins(fake_tree):
+    """`cd <worktree> ; cd <projectRoot>` — the LAST directory in force at the
+    write position decides, so this must BLOCK despite the earlier worktree cd."""
+    project_dir, wt_root, worktree = fake_tree
+    result = _run_bash_hook(
+        f'cd {worktree} ; cd {project_dir} ; echo a >> tests/p.py',
+        cwd=project_dir,
+        project_dir=project_dir,
+        worktree_root=wt_root,
+    )
+    assert result.returncode == 2, (
+        "the last cd before the redirection must win; "
+        f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "BLOCKED" in result.stderr
+
+
+def test_cd_after_the_write_does_not_apply(fake_tree):
+    """A `cd` that appears AFTER the write idiom must not retroactively
+    relocate it — the write still resolves under the project root and BLOCKS."""
+    project_dir, wt_root, worktree = fake_tree
+    result = _run_bash_hook(
+        f'echo a >> tests/p.py ; cd {worktree}',
+        cwd=project_dir,
+        project_dir=project_dir,
+        worktree_root=wt_root,
+    )
+    assert result.returncode == 2, (
+        "a trailing cd must not launder an earlier write; "
+        f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "BLOCKED" in result.stderr
+
+
+def test_unresolvable_cd_target_fails_closed(fake_tree):
+    """`cd $DEST` cannot be resolved from command text; the effective cwd stays
+    where it was (the project root) and the write BLOCKS — fail closed."""
+    project_dir, wt_root, _worktree = fake_tree
+    result = _run_bash_hook(
+        'cd "$DEST" && echo a >> tests/p.py',
+        cwd=project_dir,
+        project_dir=project_dir,
+        worktree_root=wt_root,
+    )
+    assert result.returncode == 2, (
+        "an unresolvable cd target must not be treated as an escape hatch; "
+        f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "BLOCKED" in result.stderr
+
+
+def test_pushd_and_set_location_are_recognised(fake_tree):
+    """`pushd` and `Set-Location` are honoured the same way as `cd`."""
+    project_dir, wt_root, worktree = fake_tree
+    for verb in ("pushd", "Set-Location"):
+        result = _run_bash_hook(
+            f'{verb} {worktree} && echo a >> tests/p.py',
+            cwd=project_dir,
+            project_dir=project_dir,
+            worktree_root=wt_root,
+        )
+        assert result.returncode == 0, (
+            f"{verb} must anchor the relative destination like cd does; "
+            f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+
+def test_absolute_out_of_root_target_still_blocks_after_cd(fake_tree):
+    """A `cd` into a worktree must not launder an ABSOLUTE destination that
+    lives outside every allowed root."""
+    project_dir, wt_root, worktree = fake_tree
+    outside = project_dir / "hydra_core" / "supervisor.py"
+    outside.parent.mkdir(parents=True, exist_ok=True)
+    result = _run_bash_hook(
+        f'cd {worktree} && echo a >> "{outside}"',
+        cwd=project_dir,
+        project_dir=project_dir,
+        worktree_root=wt_root,
+    )
+    assert result.returncode == 2, (
+        "an absolute in-project destination must stay blocked regardless of cd; "
+        f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "BLOCKED" in result.stderr
+
+
+def test_relative_dest_without_payload_cwd_still_blocks(fake_tree):
+    """No `cwd` in the payload means UNANCHORED: even with a `cd` in the
+    command the destination falls through to the plain extension block."""
+    project_dir, wt_root, worktree = fake_tree
+    result = _run_bash_hook(
+        f'cd {worktree} && echo a >> tests/p.py',
+        cwd=None,
+        project_dir=project_dir,
+        worktree_root=wt_root,
+    )
+    assert result.returncode == 2, (
+        "without a reported cwd the destination must fail closed; "
+        f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "BLOCKED" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Static lockstep pin (no pwsh required for the assertion itself)
+# ---------------------------------------------------------------------------
+
+
+def test_both_hooks_document_the_effective_cwd_rule():
+    """The lockstep comment block must mention the cd rule in BOTH hooks, so a
+    future editor of the Write/Edit guard knows its twin resolves cwd."""
+    bash_hook = (HOOKS_DIR / HOOK).read_text(encoding="utf-8")
+    edit_hook = (HOOKS_DIR / "hydra-block-direct-write.ps1").read_text(encoding="utf-8")
+    assert "E2-18" in bash_hook and "cd" in bash_hook
+    assert "E2-18" in edit_hook, (
+        "hydra-block-direct-write.ps1 must carry the lockstep note about the "
+        "Bash hook's cd/pushd/Set-Location resolution"
+    )


### PR DESCRIPTION
## Problem

`plugins/hydra/hooks/hydra-block-bash-writes.ps1::Test-BlockedDest` joined a relative redirection/heredoc destination with `$json.cwd` (the payload's session cwd) and ignored any `cd` / `pushd` / `Set-Location` earlier in the same command.

Inside a fix worktree, `cd <.hydra-worktrees\Hydra\fix-X> && echo x >> tests/probe.py` resolved to `<projectRoot>\tests\probe.py` — under the project root, outside every worktree root — and was **blocked**, while `hydra-block-direct-write.ps1` **allowed** the Edit tool on that very same file. The two guards that must stay in lockstep disagreed.

## Fix

The command string is scanned for `cd` / `pushd` / `Set-Location` directory tokens (quoted or bare, separated by `&&`, `;`, `||`, newline) into an ordered offset-to-effective-cwd table. Each write idiom now resolves against the directory in force at its own position:

- The **last** `cd` before the write wins; a `cd` after it does not apply.
- Relative `cd` targets compose onto the previous effective cwd, starting from `$json.cwd`.
- An unresolvable target (`$VAR`, `cd -`, `~`) leaves the effective cwd unchanged, keeping resolution inside the project root — fail closed.
- No `cwd` in the payload still means UNANCHORED and falls through to the plain extension block.

Every existing allow/block rule is otherwise unchanged. The lockstep comment block names the rule in both hooks; only the bash hook needs code.

## Tests

| Suite | Result |
| --- | --- |
| `tests/test_e2_18_bash_hook_cd_resolution.py` (new, 11 tests) | 11 passed |
| Same file against the pre-fix hook | 4 failed, 7 passed |
| `tests/test_ra1_ra9_fixes.py` + `tests/test_worktree_relocation.py` | 67 passed |

One unrelated pre-existing failure exists in any worktree checkout: `test_claude_native_configuration.py::test_operator_skills_use_canonical_namespace_without_project_duplicates` reads `.claude/agents`, which is untracked and therefore absent outside the main checkout.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
