### PR TITLE
E2-23: attended step honours task-list order across squads

### DIFF
--- a/hydra_core/cli.py
+++ b/hydra_core/cli.py
@@ -1518,7 +1518,6 @@ def _next_nonengineering_attended_task(state: HydraState, packs: dict):
     attended agent. We surface them in task-list order so the host can
     dispatch one at a time, mirroring the engineering attended flow."""
     done = set(getattr(state, "attended_completed_task_ids", []) or [])
-    _NON_ENG_ENTRYPOINTS = frozenset({"claude-skill", "claude-native", "agent-impersonation"})
     for t in getattr(state, "tasks", []):
         if str(t.task_id) in done:
             continue
@@ -1527,9 +1526,43 @@ def _next_nonengineering_attended_task(state: HydraState, packs: dict):
         pack = packs.get(t.owner_squad)
         if pack is None:
             continue
-        if pack.entrypoint in _NON_ENG_ENTRYPOINTS:
+        if pack.entrypoint in _NON_ENG_ATTENDED_ENTRYPOINTS:
             return t, pack
     return None, None
+
+
+_NON_ENG_ATTENDED_ENTRYPOINTS = frozenset(
+    {"claude-skill", "claude-native", "agent-impersonation"})
+
+
+def _next_attended_task(state: HydraState, packs: dict):
+    """First attended-eligible task in ``state.tasks`` list order.
+
+    E2-23: selection must follow the planner's task order, not drain
+    engineering first.  ``/hydra:campaign`` pre-wires executive -> creative ->
+    engineering; picking the engineering task first inverted that DAG and ran
+    the engineer without its upstream envelopes.
+
+    Returns ``(task, kind, pack)`` where ``kind`` is ``"engineering"`` (pack is
+    None — engineering opens a pp run cursor) or ``"squad"`` (pack is the
+    non-engineering squad pack whose entrypoint is host-attended).  Returns
+    ``(None, None, None)`` when nothing is pending.  Tasks already recorded in
+    ``attended_completed_task_ids`` are skipped, and non-engineering tasks
+    whose squad is unknown or headless-dispatchable are passed over (they are
+    not host-attended) so engineering behind them is still reachable.
+    """
+    done = set(getattr(state, "attended_completed_task_ids", []) or [])
+    for t in getattr(state, "tasks", []):
+        if str(t.task_id) in done:
+            continue
+        if t.owner_squad == "engineering":
+            return t, "engineering", None
+        pack = (packs or {}).get(t.owner_squad)
+        if pack is None:
+            continue
+        if pack.entrypoint in _NON_ENG_ATTENDED_ENTRYPOINTS:
+            return t, "squad", pack
+    return None, None, None
 
 
 def _resolve_pack_lead_agent(pack) -> str:
@@ -1665,9 +1698,15 @@ def _cmd_attended_step(args) -> int:
             return 1
         state = HydraState.model_validate(snap.values)
 
+        # E2-23: pick the next attended task in task-list order.  The squad
+        # only decides WHICH cursor is opened (pp run vs squad stage) — it must
+        # not reorder the planner's dependency chain.
+        packs = _discover(project)
+        _sel_task, _sel_kind, _sel_pack = _next_attended_task(state, packs)
+
         # --- Engineering task (mcp entrypoint) ---
-        task = _next_engineering_task(state)
-        if task is not None:
+        if _sel_kind == "engineering":
+            task = _sel_task
             try:
                 project_path = _resolve_task_project_path(task, state, project)
             except MissingEngineeringTargetError as _missing_target_err:
@@ -1801,9 +1840,8 @@ def _cmd_attended_step(args) -> int:
             return 0
 
         # --- Non-engineering task (claude-skill / agent-impersonation) ---
-        packs = _discover(project)
-        ne_task, ne_pack = _next_nonengineering_attended_task(state, packs)
-        if ne_task is not None:
+        if _sel_kind == "squad":
+            ne_task, ne_pack = _sel_task, _sel_pack
             task_id = str(ne_task.task_id)
             request_text = ne_task.description or state.root_goal
             pack_cwd = _resolve_pack_cwd(ne_pack, project)

--- a/tests/test_fable_audit_2.py
+++ b/tests/test_fable_audit_2.py
@@ -3156,3 +3156,97 @@ class TestF36ProceduralRiskRouting:
                 f"F36: risk class for '{kind}' must be one of {valid_classes}, "
                 f"got {risk!r}"
             )
+
+
+# ===========================================================================
+# E2-23 — _next_attended_task honours task-list order across squads
+# ===========================================================================
+
+class TestNextAttendedTaskOrder:
+    """The attended step must select the next task in planner order.
+
+    Before E2-23 the engineering leg was always drained first, so a campaign
+    wired executive -> garland -> engineering ran the engineer with neither
+    upstream envelope produced.
+    """
+
+    def _state(self, squads):
+        from hydra_core.state import HydraState, TaskState
+        state = HydraState(root_goal="campaign goal")
+        tasks = []
+        for squad in squads:
+            t = TaskState(owner_squad=squad, description=f"{squad} leg",  # type: ignore[call-arg]
+                          status="pending")
+            state.tasks.append(t)
+            tasks.append(t)
+        return state, tasks
+
+    def test_campaign_order_executive_garland_engineering(self):
+        from hydra_core.cli import _next_attended_task
+        from hydra_core.squad_loader import discover_squads
+
+        packs = discover_squads(HYDRA_ROOT)
+        state, (exec_t, garland_t, eng_t) = self._state(
+            ["executive", "garland", "engineering"])
+
+        task, kind, pack = _next_attended_task(state, packs)
+        assert task.task_id == exec_t.task_id
+        assert kind == "squad"
+        assert pack.slug == "executive"
+
+        state.attended_completed_task_ids.append(str(exec_t.task_id))
+        task, kind, pack = _next_attended_task(state, packs)
+        assert task.task_id == garland_t.task_id
+        assert kind == "squad"
+        assert pack.slug == "garland"
+
+        state.attended_completed_task_ids.append(str(garland_t.task_id))
+        task, kind, pack = _next_attended_task(state, packs)
+        assert task.task_id == eng_t.task_id
+        assert kind == "engineering"
+        assert pack is None
+
+        state.attended_completed_task_ids.append(str(eng_t.task_id))
+        assert _next_attended_task(state, packs) == (None, None, None)
+
+    def test_engineering_only_workflow_unchanged(self):
+        from hydra_core.cli import _next_attended_task
+        from hydra_core.squad_loader import discover_squads
+
+        packs = discover_squads(HYDRA_ROOT)
+        state, (eng_t,) = self._state(["engineering"])
+
+        task, kind, pack = _next_attended_task(state, packs)
+        assert task.task_id == eng_t.task_id
+        assert kind == "engineering"
+        assert pack is None
+
+    def test_engineering_first_when_listed_first(self):
+        from hydra_core.cli import _next_attended_task
+        from hydra_core.squad_loader import discover_squads
+
+        packs = discover_squads(HYDRA_ROOT)
+        state, (eng_t, sq_t) = self._state(
+            ["engineering", "customer-support"])
+
+        task, kind, pack = _next_attended_task(state, packs)
+        assert task.task_id == eng_t.task_id
+        assert kind == "engineering"
+
+        state.attended_completed_task_ids.append(str(eng_t.task_id))
+        task, kind, pack = _next_attended_task(state, packs)
+        assert task.task_id == sq_t.task_id
+        assert kind == "squad"
+        assert pack.slug == "customer-support"
+
+    def test_stub_squad_does_not_block_engineering_behind_it(self):
+        """A non-attended (stub) squad is skipped, not treated as pending."""
+        from hydra_core.cli import _next_attended_task
+        from hydra_core.squad_loader import discover_squads
+
+        packs = discover_squads(HYDRA_ROOT)
+        state, (_stub_t, eng_t) = self._state(["healthcare", "engineering"])
+
+        task, kind, pack = _next_attended_task(state, packs)
+        assert task.task_id == eng_t.task_id
+        assert kind == "engineering"


### PR DESCRIPTION
## Problem

`hydra_core/cli.py::_cmd_attended_step` consulted `_next_engineering_task` first and only fell back to `_next_nonengineering_attended_task` once engineering had nothing pending. A `/hydra:campaign` plan that pre-wires executive to garland to engineering therefore opened the **engineer** cursor on the very first `hydra.workflow.step`, before the `C_SUITE_DECISION_PACKET` or `CREATIVE_BRIEF` existed. The engineer prompt carried `origin_squad: (unspecified) / envelope_type: (unspecified)`.

## Fix

New `_next_attended_task(state, packs) -> (task, kind, pack)` walks `state.tasks` in list order, skips `attended_completed_task_ids`, and returns the first task that is either engineering (`kind="engineering"`) or a non-engineering pack whose entrypoint is host-attended (`kind="squad"`). `_cmd_attended_step` opens the matching cursor for whichever comes first, so the squad decides *which* cursor opens, never the ordering.

Non-attended squads (stub entrypoints, unknown slugs) are still skipped rather than treated as pending, so engineering behind them stays reachable. Both existing helpers are kept intact for their current callers and tests.

## Tests

Four regression tests in `tests/test_fable_audit_2.py::TestNextAttendedTaskOrder`:

- executive, garland, engineering yields executive (squad), then garland (squad), then engineering, then nothing
- an engineering-only workflow is unchanged
- engineering listed first is still selected first
- a stub squad ahead of engineering does not block it

| Suite | Result |
|---|---|
| `-k "attended or host_bridge or step"` | 73 passed, 1 failed |
| full `pytest -q` | 1681 passed, 4 skipped, 2 failed |

The 2 failures are the known worktree-environment ones, present before this change: `test_native_pack_dispatch.py::test_active_source_packs_are_host_attended_native_plugins` and `test_claude_native_configuration.py::test_operator_skills_use_canonical_namespace_without_project_duplicates`. Both fail because the `marketing-*` squad symlinks into MarketBliss are not materialised inside the worktree.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
