### PR TITLE
E2-17: HITL expiry + terminal reconcile with TheEights

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -440,6 +440,14 @@ Behaviour:
   500 per run). Drain is fail-soft: entries remain on disk when the daemon is
   still unreachable; stale `.partial` crash-residue files older than 1 hour are
   removed unconditionally.
+- **HITL lifecycle reconciliation (E2-17)**: every `hydra_gate` request Hydra
+  files with TheEights carries `expires_at` = now + `HYDRA_HITL_EXPIRY_HOURS`
+  (default 24h, the hitl-protocol wait window). Terminal transitions —
+  `hydra resume` (gate-scoped), the `abort` option, `hydra reap --apply` —
+  issue `eights.governance.hitl.resolve`, fail-soft and spooled. `hydra doctor`
+  WARNs above `HYDRA_HITL_PENDING_THRESHOLD` (default 25) pending rows, and
+  `hydra eights-hitl-reconcile [--apply]` sweeps the queue against the
+  checkpoint store, resolving only terminal/unknown workflows' rows.
 
 ## 8. Delegation to PP, ES, and RLM
 

--- a/README.md
+++ b/README.md
@@ -470,10 +470,13 @@ python -m hydra_core.cli status
 python -m hydra_core.cli trace 7f3c…
 python -m hydra_core.cli doctor
 python -m hydra_core.cli eights-drain   # drain the pending eights spool (--limit N, default 500)
+python -m hydra_core.cli eights-hitl-reconcile          # dry-run: pending HITL rows vs workflow state
+python -m hydra_core.cli eights-hitl-reconcile --apply  # resolve rows whose workflow is terminal/unknown
 ```
 
-`doctor` surfaces three additional probes beyond the basic squad/constitution checks:
+`doctor` surfaces four additional probes beyond the basic squad/constitution checks:
 - **eights spool depth** — warns when the pending spool exceeds `HYDRA_EIGHTS_SPOOL_WARN` (default 100); suggests `hydra eights-drain` when over threshold.
+- **eights HITL backlog** — warns when pending `hydra_gate` requests in TheEights exceed `HYDRA_HITL_PENDING_THRESHOLD` (default 25); suggests `hydra eights-hitl-reconcile`. Distinct from the spool line: the spool counts undelivered calls, this counts gates the shared ledger still holds open.
 - **AgentSmith venom back-channel** — probes `agentsmith.venom.cross_check` and surfaces the smith→hydra back-channel state (rationale field); `hydra-mcp-unavailable` means the gateway is not wired into backends.json.
 - **WS-AUTH operator key** — checks whether `HYDRA_OPERATOR_KEY` is provisioned (env or any backend spec's `env` block in `~/.hydra/backends.json`); unprovisioned means `xenia send_response` / `execute_approved` reject all tokens fail-closed.
 

--- a/hydra_core/cli.py
+++ b/hydra_core/cli.py
@@ -29,6 +29,7 @@ import re
 import sys
 import warnings
 from pathlib import Path
+from typing import Callable
 from uuid import uuid4
 
 # Validation regex for workflow ids supplied via --workflow-id.
@@ -100,6 +101,22 @@ class _NullDispatcher:
         return {"status": "stub", "summary": f"would invoke /{skill}", "args": args}
     def run_host_agent(self, agent_type, prompt, *, cwd=None, timeout_s=None):
         return None
+
+
+def _hitl_backlog_line(rows: list | None, threshold: int) -> str:
+    """Render the doctor's TheEights HITL backlog line (E2-17).
+
+    Pure so it is testable without a daemon. ``rows=None`` means the daemon
+    did not answer — a WARN, never a FAIL (doctor degrades open on eights).
+    """
+    if rows is None:
+        return ("WARN: eights HITL backlog unknown — daemon did not answer "
+                "hitl.list (pending gates may be accumulating)")
+    if len(rows) > threshold:
+        return (f"WARN: eights HITL pending={len(rows)} exceeds "
+                f"threshold={threshold} — run `hydra eights-hitl-reconcile` "
+                "to see which are zombies, then --apply to close them")
+    return f"OK:   eights HITL pending={len(rows)} (threshold={threshold})"
 
 
 def _cmd_doctor(args) -> int:
@@ -255,6 +272,25 @@ def _cmd_doctor(args) -> int:
             err = (res.get("error", "(no error field)")
                    if isinstance(res, dict) else f"non-dict {type(res).__name__}")
             print(f"WARN: {server} unreachable — {err}")
+
+    # --- E2-17: TheEights HITL backlog (consumer hydra) ---------------------
+    # Separate from the spool-depth line above: the spool counts calls Hydra
+    # could not deliver, this counts gates the ledger still holds open.
+    try:
+        _hitl_thresh = int(os.environ.get("HYDRA_HITL_PENDING_THRESHOLD", "25"))
+    except ValueError:
+        _hitl_thresh = 25
+    if "eights" in servers:
+        try:
+            from .eights.attestation import EightsAttestor
+            _hitl_rows = EightsAttestor(dispatcher=dispatcher).hitl_list()
+        except Exception as _hitl_exc:  # noqa: BLE001 — never crash doctor
+            print(_hitl_backlog_line(None, _hitl_thresh)
+                  + f" ({type(_hitl_exc).__name__}: {_hitl_exc})")
+        else:
+            print(_hitl_backlog_line(_hitl_rows, _hitl_thresh))
+    else:
+        print("WARN: eights not registered — skipping HITL backlog check")
 
     # --- RA-6: AgentSmith venom cross-check / smith→hydra back-channel ------
     # Informational only: surfaces the back-channel state (rationale field) but
@@ -853,6 +889,77 @@ def _prune_spooled_hitl_requests(workflow_id: str, gate_node: str | None) -> int
     return pruned
 
 
+def _reconcile_attestor(project: Path):
+    """Build an EightsAttestor bound to the live MCP dispatcher (E2-17).
+
+    Its own seam so terminal-transition reconciliation is stubbable in tests
+    without spawning the eights daemon.
+    """
+    from .dispatcher import MCPStdioDispatcher
+    from .eights.attestation import EightsAttestor
+    return EightsAttestor(dispatcher=MCPStdioDispatcher(project))
+
+
+def _make_phase_lookup(project: Path) -> Callable[[str], str | None]:
+    """Return ``workflow_id -> phase | None`` over Hydra's checkpoint store.
+
+    ``None`` means Hydra has no state for that workflow — an orphan row from
+    a wiped checkpoint db or a foreign run id. Results are memoized because
+    a reconcile sweep sees many rows per workflow.
+    """
+    from .supervisor import build_supervisor, _PurePythonRunner
+    sup = build_supervisor(project_root=project, dispatcher=_NullDispatcher())
+    if isinstance(sup, _PurePythonRunner):
+        # No checkpointer → every workflow is "unknown"; the reconcile caller
+        # still resolves those rows (they can never be advanced again).
+        return lambda _wf: None
+
+    cache: dict[str, str | None] = {}
+
+    def _lookup(workflow_id: str) -> str | None:
+        if workflow_id in cache:
+            return cache[workflow_id]
+        phase: str | None = None
+        try:
+            snap = sup.get_state({"configurable": {"thread_id": workflow_id}})
+            if snap is not None and snap.values:
+                phase = snap.values.get("phase")
+        except Exception:  # noqa: BLE001 — one bad thread never aborts a sweep
+            phase = None
+        cache[workflow_id] = phase
+        return phase
+
+    return _lookup
+
+
+def _resolve_eights_hitl_for_workflow(
+    project: Path, workflow_id: str, *, note: str, decision: str = "rejected",
+    gate_node: str | None = None, dispatcher=None,
+) -> dict:
+    """Close a workflow's pending TheEights HITL rows. Never raises (E2-17).
+
+    ``dispatcher`` reuses a caller's already-built transport instead of
+    spawning a second eights connection. A caller holding a null dispatcher
+    (``hydra resume`` without ``--live``) therefore no-ops here rather than
+    starting the daemon mid-resume; those rows are swept by
+    ``hydra eights-hitl-reconcile`` / ``hydra reap --apply`` instead.
+    """
+    try:
+        from .eights.hitl_reconcile import resolve_for_workflow
+        if dispatcher is not None:
+            from .eights.attestation import EightsAttestor
+            attestor = EightsAttestor(dispatcher=dispatcher, workflow_id=workflow_id)
+        else:
+            attestor = _reconcile_attestor(project)
+        return resolve_for_workflow(
+            attestor, workflow_id,
+            note=note, decision=decision, gate_node=gate_node,
+        )
+    except Exception as exc:  # noqa: BLE001 — reconciliation is never a gate
+        return {"pending": 0, "resolved": 0, "failed": 0, "unavailable": True,
+                "error": f"{type(exc).__name__}: {exc}"}
+
+
 def _release_resume_lock(fd, lock_path) -> None:
     import os as _os
     try:
@@ -1229,11 +1336,27 @@ def _cmd_resume_locked(args, project: Path, wf: str, action: str, option) -> int
     # C3: prevent a later spool replay from filing a ticket for this
     # now-resolved gate (late-spool orphan reconciliation, gate-identity-keyed).
     pruned_spool = _prune_spooled_hitl_requests(wf, resolution.get("gate_node"))
+
+    # E2-17: the gate is now resolved on the Hydra side — close the matching
+    # row in TheEights' shared ledger too, or it stays pending forever. Scoped
+    # to the resolved gate identity (same key the spool prune uses), so another
+    # open gate in this workflow survives. Fail-soft: an unreachable daemon
+    # spools the resolve for the next drain.
+    _terminal_resolution = action == "reject" or option == "abort"
+    _eights_hitl = _resolve_eights_hitl_for_workflow(
+        project, wf,
+        note=("workflow terminal: surfaced" if _terminal_resolution
+              else f"hydra resume: {action}"),
+        decision="rejected" if _terminal_resolution else "approved",
+        gate_node=resolution.get("gate_node") or None,
+        dispatcher=dispatcher,
+    )
     emit(project, wf, "hitl_resumed", {
         "action": action,
         "option": option,
         "gate_node": resolution.get("gate_node"),
         "pruned_spooled_hitl_requests": pruned_spool,
+        "eights_hitl_resolved": _eights_hitl.get("resolved", 0),
     })
 
     # F10: abort option → park the workflow surfaced without resuming the graph.
@@ -2529,9 +2652,32 @@ def _cmd_reap(args) -> int:
             finally:
                 _release_resume_lock(lock_fd, lock_path)
 
+    # E2-17: a reaped workflow is terminal — close its pending rows in
+    # TheEights' shared ledger. One hitl.list for the whole sweep; fail-soft
+    # (an unreachable daemon leaves the rows and spools nothing to lose).
+    eights_hitl = {"resolved": 0, "failed": 0, "pending": 0}
+    if do_apply and reaped:
+        try:
+            from .eights.hitl_reconcile import resolve_for_workflow
+            attestor = _reconcile_attestor(project)
+            rows = attestor.hitl_list()
+            if rows is None:
+                eights_hitl["unavailable"] = True
+            else:
+                for wf in reaped:
+                    s = resolve_for_workflow(
+                        attestor, wf, rows=rows,
+                        note="workflow terminal: surfaced",
+                    )
+                    for k in ("resolved", "failed", "pending"):
+                        eights_hitl[k] += s.get(k, 0)
+        except Exception as exc:  # noqa: BLE001 — never fail a reap on this
+            eights_hitl["error"] = f"{type(exc).__name__}: {exc}"
+
     print(json.dumps({
         "mode": "apply" if do_apply else "dry-run",
         "older_than_hours": older_than_h,
+        "eights_hitl": eights_hitl,
         "scanned": len(thread_ids),
         "candidate_count": len(candidates),
         "candidates": candidates,
@@ -3265,6 +3411,36 @@ def _cmd_eights_drain(args) -> int:
     return 0
 
 
+def _cmd_eights_hitl_reconcile(args) -> int:
+    """`hydra eights-hitl-reconcile [--apply] [--limit N]` (E2-17).
+
+    Lists TheEights' pending `hydra_gate` requests, matches each row's
+    workflow_id against Hydra's checkpoint store, and resolves the rows whose
+    workflow is terminal (done/surfaced) or unknown to Hydra. Rows for an
+    ACTIVE workflow are never touched — those are real gates awaiting a human.
+
+    Dry-run by default (mirrors `reap`); prints a JSON summary either way.
+    """
+    project = Path(args.project) if args.project else Path.cwd()
+    do_apply = bool(getattr(args, "apply", False))
+    limit = getattr(args, "limit", None)
+
+    from .eights.hitl_reconcile import reconcile
+    try:
+        attestor = _reconcile_attestor(project)
+        lookup = _make_phase_lookup(project)
+    except Exception as exc:  # noqa: BLE001 — report, never traceback
+        print(json.dumps({"error": f"{type(exc).__name__}: {exc}"}, indent=2),
+              file=sys.stderr)
+        return 1
+
+    summary = reconcile(attestor, lookup, apply=do_apply,
+                        limit=int(limit) if limit is not None else None)
+    summary["mode"] = "apply" if do_apply else "dry-run"
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(prog="hydra", description="Enterprise Agent Mesh supervisor")
     ap.add_argument("--project", help="Project root (defaults to cwd)")
@@ -3483,6 +3659,25 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
 
+    # E2-17: HITL lifecycle reconciliation against TheEights' shared ledger.
+    ehr = sub.add_parser(
+        "eights-hitl-reconcile",
+        help=(
+            "Reconcile TheEights' pending HITL requests against Hydra "
+            "workflow state. Resolves rows whose workflow is terminal or "
+            "unknown; leaves active gates alone. Dry-run unless --apply. "
+            "Prints JSON: {pending, terminal, unknown, active, resolved}."
+        ),
+    )
+    ehr.add_argument(
+        "--apply", action="store_true",
+        help="Actually resolve the zombie rows (default: dry-run report only).",
+    )
+    ehr.add_argument(
+        "--limit", type=int, default=None, metavar="N",
+        help="Examine at most N pending rows (default: all).",
+    )
+
     # gateway management
     sub.add_parser("gateway-backup")
     sub.add_parser("gateway-export-backends")
@@ -3553,6 +3748,7 @@ def main(argv: list[str] | None = None) -> int:
         "ingest": _cmd_ingest,
         "replay": _cmd_replay,
         "eights-drain": _cmd_eights_drain,
+        "eights-hitl-reconcile": _cmd_eights_hitl_reconcile,
         "gateway-backup": _cmd_gateway_backup,
         "gateway-export-backends": _cmd_gateway_export_backends,
         "gateway-migrate-hooks": _cmd_gateway_migrate_hooks,

--- a/hydra_core/eights/attestation.py
+++ b/hydra_core/eights/attestation.py
@@ -66,8 +66,73 @@ _SPOOLABLE_TOOLS = frozenset({
     "eights.constitution.attest",
     "eights.hydra.envelope.record",
     "eights.governance.hitl.request",
+    # E2-17: a terminal-transition resolve MUST survive an offline daemon —
+    # otherwise the ticket it was meant to close stays pending forever (the
+    # exact zombie class this finding is about). The spooled args carry their
+    # own `envelope` (with the capability token), which `replay_pending`
+    # preserves because the spooled args override the default envelope. A
+    # token minted now may have expired by replay time; the replay then fails
+    # and is retried/aged out like any other spool entry.
+    "eights.governance.hitl.resolve",
     "eights.evolution.propose",
 })
+
+# E2-17: HITL request expiry. `plugins/hydra/skills/hitl-protocol/SKILL.md`
+# documents the wait behaviour as "mark the workflow `surfaced` after
+# `expires_at` (default 24h)", so 24h is the protocol default here.
+# Override with HYDRA_HITL_EXPIRY_HOURS.
+_HITL_EXPIRY_HOURS_DEFAULT = 24.0
+
+
+def hitl_expiry_hours() -> float:
+    """Configured HITL expiry window in hours (HYDRA_HITL_EXPIRY_HOURS).
+
+    Falls back to the protocol default on an unset, unparseable or
+    non-positive value — an expiry of zero would file already-expired
+    requests, which is worse than no expiry at all.
+    """
+    raw = (_os.environ.get("HYDRA_HITL_EXPIRY_HOURS") or "").strip()
+    if not raw:
+        return _HITL_EXPIRY_HOURS_DEFAULT
+    try:
+        hours = float(raw)
+    except ValueError:
+        return _HITL_EXPIRY_HOURS_DEFAULT
+    return hours if hours > 0 else _HITL_EXPIRY_HOURS_DEFAULT
+
+
+def hitl_expires_at(now: Any = None) -> str:
+    """ISO-8601 UTC instant at which a HITL request filed *now* expires."""
+    from datetime import datetime, timedelta, timezone
+    base = now or datetime.now(timezone.utc)
+    stamp = (base + timedelta(hours=hitl_expiry_hours())).replace(microsecond=0)
+    return stamp.isoformat().replace("+00:00", "Z")
+
+
+def _mint_hitl_resolve_token(*, request_id: str, workflow_id: str) -> Optional[dict]:
+    """Mint the WS-AUTH operator-capability token `hitl.resolve` requires.
+
+    TheEights' `hitlResolve` fails closed without a token whose capability is
+    `hitl.resolve` and whose resource_id is the request id. When
+    HYDRA_OPERATOR_KEY is unset the mint degrades (sig.value=None) and the
+    daemon rejects it — the resolve then spools like any other failed call.
+    """
+    try:
+        import time as _t
+        from ..auth.capability import mint_capability
+        now = int(_t.time())
+        return mint_capability({
+            "v": 1,
+            "actor_id": _os.environ.get("HYDRA_OPERATOR_ACTOR") or "hydra.supervisor",
+            "actor_kind": "human",
+            "capability": "hitl.resolve",
+            "resource_id": str(request_id),
+            "workflow_id": str(workflow_id or request_id),
+            "issued_at": now,
+            "exp": now + 900,
+        }, now=now)
+    except Exception:  # noqa: BLE001 — a mint failure must never block the resolve
+        return None
 
 _REPLAY_THREADS: dict[str, threading.Thread] = {}
 _REPLAY_THREADS_LOCK = threading.Lock()
@@ -637,9 +702,76 @@ class EightsAttestor:
                 "options": list(hitl_envelope.get("options") or []),
                 "default_option": hitl_envelope.get("default_option"),
                 "gate_node": gate_node or "unspecified",
-                "expires_at": hitl_envelope.get("expires_at"),
+                # E2-17: never file an immortal request. An unset expires_at is
+                # what left 858 pending zombies in the shared ledger.
+                "expires_at": hitl_envelope.get("expires_at") or hitl_expires_at(),
             },
         }, guard_key="hitl_request")
+
+    def hitl_list(
+        self,
+        *,
+        status: str = "pending",
+        kind: Optional[str] = "hydra_gate",
+    ) -> Optional[list[dict]]:
+        """List HITL rows from the shared ledger (E2-17).
+
+        Returns the rows, or ``None`` when the daemon did not service the call
+        (unreachable / disabled) so callers can distinguish "no backlog" from
+        "backlog unknown". ``kind`` filters to Hydra-filed gates by default;
+        pass ``None`` for every consumer's rows.
+
+        Not routed through ``_call``: hitl.list returns a JSON *array*, which
+        ``_call`` would discard as a non-dict result. It is also read-only, so
+        there is nothing to spool on failure.
+        """
+        if not self.enabled or self.dispatcher is None:
+            return None
+        args = {"envelope": self._eights_envelope(), "status": status}
+        try:
+            result = self._dispatch_call("eights.governance.hitl.list", args)
+        except Exception:  # noqa: BLE001 — read-only probe, never raises upward
+            return None
+        if not self._is_success_envelope(result):
+            return None
+        inner = result.get("result", result) if isinstance(result, dict) else None
+        if isinstance(inner, dict):
+            inner = inner.get("rows") or inner.get("requests")
+        if not isinstance(inner, list):
+            return None
+        rows = [r for r in inner if isinstance(r, dict)]
+        if kind:
+            rows = [r for r in rows if r.get("kind") == kind]
+        return rows
+
+    def hitl_resolve(
+        self,
+        *,
+        request_id: str,
+        decision: str = "rejected",
+        note: str = "",
+        workflow_id: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Resolve one pending HITL request in the shared ledger (E2-17).
+
+        Fail-soft and spooled like every other durable eights write: a
+        rejected or unreachable call returns None and replays on drain.
+        """
+        rid = str(request_id or "").strip()
+        if not rid:
+            return None
+        envelope = self._eights_envelope(workflow_id=workflow_id)
+        token = _mint_hitl_resolve_token(
+            request_id=rid, workflow_id=str(workflow_id or ""),
+        )
+        if token is not None:
+            envelope["capability_token"] = token
+        return self._call("eights.governance.hitl.resolve", {
+            "envelope": envelope,
+            "request_id": rid,
+            "decision": decision,
+            "note": note,
+        })
 
     # ---------- redaction ----------
 

--- a/hydra_core/eights/hitl_reconcile.py
+++ b/hydra_core/eights/hitl_reconcile.py
@@ -1,0 +1,178 @@
+"""HITL lifecycle reconciliation against TheEights' shared ledger (E2-17).
+
+Hydra files a `hydra_gate` HITL request with TheEights on every gate it
+raises, but nothing ever closed those rows: a workflow that reached a
+terminal phase (resumed, rejected, aborted, reaped) left its ticket pending
+forever. The 2026-09-01 E2E trace measured 858 pending rows across 763
+distinct workflows, all of them terminal — the shared ledger was unusable as
+an operator work queue.
+
+This module holds the pure lookup/matching logic so the CLI wiring stays
+thin and testable with a stub dispatcher:
+
+  * :func:`row_workflow_id` / :func:`row_gate_node` — read the frozen
+    `hydra_gate` payload contract (see ``EightsAttestor.hitl_request``).
+  * :func:`resolve_for_workflow` — close one workflow's pending rows on a
+    terminal transition (resume resolution, abort, reap).
+  * :func:`reconcile` — the sweep behind ``hydra eights-hitl-reconcile``.
+
+Every call here is fail-soft: an unreachable daemon yields
+``unavailable: True`` and resolves nothing. Nothing in this module deletes
+or mutates local state.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Iterable, Optional
+
+# Mirrors `hydra_core.cli._TERMINAL_PHASES`; kept local so this module stays
+# importable without pulling the CLI in.
+TERMINAL_PHASES = frozenset({"done", "surfaced"})
+
+
+def _payload(row: dict) -> dict:
+    """The row's payload as a dict (tolerating a JSON-string transport)."""
+    payload = row.get("payload")
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except ValueError:
+            return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def row_workflow_id(row: dict) -> str:
+    """Workflow id a `hydra_gate` row belongs to ('' when unattributable)."""
+    wf = _payload(row).get("workflow_id")
+    if wf:
+        return str(wf)
+    return str(row.get("run_id") or "")
+
+
+def row_gate_node(row: dict) -> str:
+    """Gate identity of a `hydra_gate` row ('' for pre-C2 rows)."""
+    return str(_payload(row).get("gate_node") or "")
+
+
+def resolve_rows(
+    attestor: Any,
+    rows: Iterable[dict],
+    *,
+    note: str,
+    decision: str = "rejected",
+) -> dict[str, int]:
+    """Resolve every row, counting successes and daemon refusals."""
+    resolved = 0
+    failed = 0
+    for row in rows:
+        request_id = row.get("request_id")
+        if not request_id:
+            continue
+        out = attestor.hitl_resolve(
+            request_id=str(request_id),
+            decision=decision,
+            note=note,
+            workflow_id=row_workflow_id(row) or None,
+        )
+        if out is None:
+            failed += 1
+        else:
+            resolved += 1
+    return {"resolved": resolved, "failed": failed}
+
+
+def resolve_for_workflow(
+    attestor: Any,
+    workflow_id: str,
+    *,
+    note: str,
+    decision: str = "rejected",
+    rows: Optional[list[dict]] = None,
+    gate_node: Optional[str] = None,
+) -> dict[str, Any]:
+    """Close the pending ledger rows belonging to one workflow.
+
+    ``rows`` lets a caller sweeping many workflows (``hydra reap --apply``)
+    pay for a single ``hitl.list`` instead of one per workflow. When
+    ``gate_node`` is given, only that gate's rows are closed — the same
+    gate-identity scoping ``_prune_spooled_hitl_requests`` uses, so a
+    different unresolved gate in the same workflow survives.
+    """
+    if rows is None:
+        rows = attestor.hitl_list()
+    if rows is None:
+        return {"pending": 0, "resolved": 0, "failed": 0, "unavailable": True}
+    wf = str(workflow_id)
+    matched = [r for r in rows if row_workflow_id(r) == wf]
+    if gate_node:
+        matched = [r for r in matched if row_gate_node(r) == gate_node]
+    out = resolve_rows(attestor, matched, note=note, decision=decision)
+    out["pending"] = len(matched)
+    out["unavailable"] = False
+    return out
+
+
+def reconcile(
+    attestor: Any,
+    phase_lookup: Callable[[str], Optional[str]],
+    *,
+    apply: bool = False,
+    limit: Optional[int] = None,
+) -> dict[str, Any]:
+    """Sweep the pending queue against Hydra's own workflow state.
+
+    ``phase_lookup(workflow_id)`` returns the workflow's phase, or ``None``
+    when Hydra has no checkpoint for it (an orphan from a wiped checkpoint
+    db, a foreign run id, or an unattributable row). Terminal and unknown
+    rows are the zombies; active rows are left strictly alone.
+
+    Returns ``{pending, terminal, unknown, active, resolved, failed, mode}``.
+    With ``apply=False`` nothing is written and ``resolved`` is 0.
+    """
+    rows = attestor.hitl_list()
+    if rows is None:
+        return {
+            "error": "eights_unreachable",
+            "pending": 0, "terminal": 0, "unknown": 0,
+            "active": 0, "resolved": 0, "failed": 0,
+        }
+    if limit is not None and limit >= 0:
+        rows = rows[:limit]
+
+    terminal: list[tuple[dict, str]] = []
+    unknown: list[dict] = []
+    active = 0
+    for row in rows:
+        wf = row_workflow_id(row)
+        phase = phase_lookup(wf) if wf else None
+        if phase is None:
+            unknown.append(row)
+        elif phase in TERMINAL_PHASES:
+            terminal.append((row, phase))
+        else:
+            active += 1
+
+    resolved = 0
+    failed = 0
+    if apply:
+        for row, phase in terminal:
+            out = resolve_rows(
+                attestor, [row], note=f"workflow terminal: {phase}",
+            )
+            resolved += out["resolved"]
+            failed += out["failed"]
+        if unknown:
+            out = resolve_rows(
+                attestor, unknown, note="workflow terminal: unknown",
+            )
+            resolved += out["resolved"]
+            failed += out["failed"]
+
+    return {
+        "pending": len(rows),
+        "terminal": len(terminal),
+        "unknown": len(unknown),
+        "active": active,
+        "resolved": resolved,
+        "failed": failed,
+    }

--- a/plugins/hydra/skills/hitl-protocol/SKILL.md
+++ b/plugins/hydra/skills/hitl-protocol/SKILL.md
@@ -11,6 +11,27 @@ Hydra is HITL-first. Three rules every agent honors:
 2. **You do not paraphrase the request.** Render the `HITL_REQUEST` envelope verbatim — its `reason`, `summary`, `options`, and `default_option`.
 3. **You wait.** If the operator does not respond, mark the workflow `surfaced` after `expires_at` (default 24h) and emit a postmortem note.
 
+## Expiry and ledger reconciliation
+
+Every gate Hydra files with TheEights (`eights.governance.hitl.request`,
+kind `hydra_gate`) carries `expires_at` = now + `HYDRA_HITL_EXPIRY_HOURS`
+(default 24h, the rule-3 window). Filing without an expiry is what produced
+858 immortal pending rows (finding E2-17).
+
+Terminal transitions close the ledger row as well as the local gate:
+`hydra resume` (any resolution, scoped to that gate's `gate_node`), the
+`abort` option, and `hydra reap --apply` all issue
+`eights.governance.hitl.resolve`. The call is fail-soft and spooled, so an
+offline daemon replays it on the next `hydra eights-drain`.
+
+Operator surfaces:
+
+- `hydra doctor` WARNs when pending `hydra_gate` rows exceed
+  `HYDRA_HITL_PENDING_THRESHOLD` (default 25).
+- `hydra eights-hitl-reconcile [--apply] [--limit N]` sweeps the pending
+  queue against Hydra's checkpoint store and resolves rows whose workflow is
+  terminal or unknown. Rows for an active workflow are never touched.
+
 ## Gate Placement in the Supervisor Graph
 
 LangGraph builds with `interrupt_before=["approval", "synthesis"]`. Additional ad-hoc gates fire from inside `dispatch` when a squad emits a `HITL_REQUEST`.

--- a/tests/test_hitl_expiry_reconcile.py
+++ b/tests/test_hitl_expiry_reconcile.py
@@ -1,0 +1,449 @@
+"""E2-17: HITL request expiry + terminal reconciliation with TheEights.
+
+Regression cover for the 858-pending-zombie finding: Hydra filed
+`hydra_gate` HITL requests with no `expires_at` and never resolved them when
+the originating workflow reached a terminal phase.
+
+Every test stubs the dispatcher — no test here may reach the real daemon.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from hydra_core import cli
+from hydra_core.eights import hitl_reconcile
+from hydra_core.eights.attestation import (
+    EightsAttestor,
+    hitl_expires_at,
+    hitl_expiry_hours,
+)
+
+
+class _StubDispatcher:
+    """Records every eights call; answers hitl.list from `rows`."""
+
+    def __init__(self, rows: list[dict] | None = None, ok: bool = True):
+        self.calls: list[dict] = []
+        self.rows = rows
+        self.ok = ok
+
+    def call_mcp(self, server, tool, args, **_kw):
+        self.calls.append({"server": server, "tool": tool, "args": args})
+        if not self.ok:
+            return {"status": "failed", "error": "daemon down"}
+        if tool == "eights.governance.hitl.list":
+            return {"status": "done", "result": list(self.rows or [])}
+        return {"status": "done", "result": {}}
+
+    def spawn_subprocess(self, *a, **k):
+        return {"status": "done", "stdout": "", "stderr": ""}
+
+    def emit_claude_prompt(self, *a, **k):
+        return {"status": "host_pickup_required"}
+
+    def invoke_claude_skill(self, *a, **k):
+        return {"status": "host_pickup_required"}
+
+
+def _row(request_id: str, workflow_id: str, gate_node: str = "approval") -> dict:
+    return {
+        "request_id": request_id,
+        "run_id": workflow_id,
+        "kind": "hydra_gate",
+        "status": "pending",
+        "payload": {
+            "hitl_id": f"h-{request_id}",
+            "workflow_id": workflow_id,
+            "reason": "high_risk",
+            "gate_node": gate_node,
+            "expires_at": None,
+        },
+    }
+
+
+def _tools(disp: _StubDispatcher) -> list[str]:
+    return [c["tool"] for c in disp.calls]
+
+
+# ---------------- 1. expiry on filed requests ----------------
+
+def test_hitl_request_carries_expires_at(tmp_path, monkeypatch):
+    monkeypatch.setenv("HYDRA_EIGHTS_SPOOL", str(tmp_path / "spool"))
+    d = _StubDispatcher()
+    EightsAttestor(dispatcher=d, workflow_id="wf-1").hitl_request(
+        {"id": "h1", "workflow_id": "wf-1", "reason": "high_risk"},
+        gate_node="approval",
+    )
+    payload = d.calls[0]["args"]["payload"]
+    expires = payload["expires_at"]
+    assert expires, "every filed HITL request must carry expires_at (E2-17)"
+    parsed = datetime.fromisoformat(expires.replace("Z", "+00:00"))
+    delta_h = (parsed - datetime.now(timezone.utc)).total_seconds() / 3600.0
+    assert 23.0 < delta_h <= 24.1  # protocol default is 24h
+
+
+def test_hitl_request_expiry_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("HYDRA_EIGHTS_SPOOL", str(tmp_path / "spool"))
+    monkeypatch.setenv("HYDRA_HITL_EXPIRY_HOURS", "72")
+    assert hitl_expiry_hours() == 72.0
+    d = _StubDispatcher()
+    EightsAttestor(dispatcher=d).hitl_request({"id": "h1", "workflow_id": "wf"})
+    expires = d.calls[0]["args"]["payload"]["expires_at"]
+    parsed = datetime.fromisoformat(expires.replace("Z", "+00:00"))
+    assert (parsed - datetime.now(timezone.utc)) > timedelta(hours=71)
+
+
+@pytest.mark.parametrize("bad", ["", "abc", "0", "-5"])
+def test_hitl_expiry_falls_back_on_bad_env(monkeypatch, bad):
+    monkeypatch.setenv("HYDRA_HITL_EXPIRY_HOURS", bad)
+    assert hitl_expiry_hours() == 24.0
+
+
+def test_hitl_request_preserves_caller_expiry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HYDRA_EIGHTS_SPOOL", str(tmp_path / "spool"))
+    d = _StubDispatcher()
+    EightsAttestor(dispatcher=d).hitl_request(
+        {"id": "h1", "workflow_id": "wf", "expires_at": "2030-01-01T00:00:00Z"},
+    )
+    assert d.calls[0]["args"]["payload"]["expires_at"] == "2030-01-01T00:00:00Z"
+
+
+def test_hitl_expires_at_is_utc_iso():
+    stamp = hitl_expires_at(datetime(2026, 1, 1, tzinfo=timezone.utc))
+    assert stamp == "2026-01-02T00:00:00Z"
+
+
+# ---------------- 2. list / resolve adapter ----------------
+
+def test_hitl_list_filters_to_hydra_gates():
+    d = _StubDispatcher(rows=[
+        _row("r1", "wf-1"),
+        {"request_id": "r2", "kind": "smith.reregister", "payload": {}},
+    ])
+    rows = EightsAttestor(dispatcher=d).hitl_list()
+    assert [r["request_id"] for r in rows] == ["r1"]
+    assert EightsAttestor(dispatcher=d).hitl_list(kind=None) is not None
+    assert len(EightsAttestor(dispatcher=d).hitl_list(kind=None)) == 2
+
+
+def test_hitl_list_returns_none_when_daemon_down():
+    assert EightsAttestor(dispatcher=_StubDispatcher(ok=False)).hitl_list() is None
+    assert EightsAttestor().hitl_list() is None
+
+
+def test_hitl_resolve_call_shape_and_capability(tmp_path, monkeypatch):
+    monkeypatch.setenv("HYDRA_EIGHTS_SPOOL", str(tmp_path / "spool"))
+    d = _StubDispatcher()
+    EightsAttestor(dispatcher=d).hitl_resolve(
+        request_id="hitl_abc", decision="rejected",
+        note="workflow terminal: surfaced", workflow_id="wf-1",
+    )
+    call = d.calls[0]
+    assert call["tool"] == "eights.governance.hitl.resolve"
+    assert call["args"]["request_id"] == "hitl_abc"
+    assert call["args"]["decision"] == "rejected"
+    assert call["args"]["note"] == "workflow terminal: surfaced"
+    token = call["args"]["envelope"]["capability_token"]
+    assert token["capability"] == "hitl.resolve"
+    assert token["resource_id"] == "hitl_abc"
+
+
+def test_hitl_resolve_is_spooled_when_daemon_down(tmp_path, monkeypatch):
+    spool_root = tmp_path / "spool"
+    monkeypatch.setenv("HYDRA_EIGHTS_SPOOL", str(spool_root))
+    from hydra_core.eights.pending_spool import PendingSpool
+    a = EightsAttestor(dispatcher=_StubDispatcher(ok=False),
+                       spool=PendingSpool(root=spool_root))
+    assert a.hitl_resolve(request_id="hitl_abc", note="terminal") is None
+    spooled = [json.loads(p.read_text(encoding="utf-8"))
+               for p in spool_root.glob("*.json")]
+    assert any(s["tool"] == "eights.governance.hitl.resolve" for s in spooled)
+
+
+def test_hitl_resolve_ignores_blank_request_id():
+    d = _StubDispatcher()
+    assert EightsAttestor(dispatcher=d).hitl_resolve(request_id="") is None
+    assert d.calls == []
+
+
+# ---------------- 3. reconcile logic ----------------
+
+class _FakeAttestor:
+    def __init__(self, rows):
+        self._rows = rows
+        self.resolved: list[dict] = []
+
+    def hitl_list(self, **_kw):
+        return None if self._rows is None else list(self._rows)
+
+    def hitl_resolve(self, *, request_id, decision="rejected", note="",
+                     workflow_id=None):
+        self.resolved.append({"request_id": request_id, "decision": decision,
+                              "note": note, "workflow_id": workflow_id})
+        return {"request_id": request_id, "status": decision}
+
+
+def _phases(mapping):
+    return lambda wf: mapping.get(wf)
+
+
+def test_reconcile_dry_run_classifies_without_resolving():
+    a = _FakeAttestor([_row("r1", "wf-term"), _row("r2", "wf-live"),
+                       _row("r3", "wf-gone")])
+    out = hitl_reconcile.reconcile(
+        a, _phases({"wf-term": "surfaced", "wf-live": "dispatch"}),
+        apply=False,
+    )
+    assert out["pending"] == 3
+    assert out["terminal"] == 1
+    assert out["active"] == 1
+    assert out["unknown"] == 1
+    assert out["resolved"] == 0
+    assert a.resolved == []
+
+
+def test_reconcile_apply_resolves_terminal_and_unknown_only():
+    a = _FakeAttestor([_row("r1", "wf-term"), _row("r2", "wf-live"),
+                       _row("r3", "wf-gone")])
+    out = hitl_reconcile.reconcile(
+        a, _phases({"wf-term": "done", "wf-live": "approval"}), apply=True,
+    )
+    assert out["resolved"] == 2
+    ids = sorted(r["request_id"] for r in a.resolved)
+    assert ids == ["r1", "r3"]
+    assert all(r["decision"] == "rejected" for r in a.resolved)
+    notes = {r["request_id"]: r["note"] for r in a.resolved}
+    assert notes["r1"] == "workflow terminal: done"
+    assert notes["r3"] == "workflow terminal: unknown"
+
+
+def test_reconcile_honours_limit():
+    a = _FakeAttestor([_row(f"r{i}", "wf-gone") for i in range(10)])
+    out = hitl_reconcile.reconcile(a, _phases({}), apply=True, limit=3)
+    assert out["pending"] == 3
+    assert out["resolved"] == 3
+
+
+def test_reconcile_degrades_when_eights_unreachable():
+    out = hitl_reconcile.reconcile(_FakeAttestor(None), _phases({}), apply=True)
+    assert out["error"] == "eights_unreachable"
+    assert out["resolved"] == 0
+
+
+def test_resolve_for_workflow_is_gate_scoped():
+    a = _FakeAttestor([_row("r1", "wf-1", gate_node="approval"),
+                       _row("r2", "wf-1", gate_node="dispatch"),
+                       _row("r3", "wf-2", gate_node="approval")])
+    out = hitl_reconcile.resolve_for_workflow(
+        a, "wf-1", note="hydra resume: approve", decision="approved",
+        gate_node="approval",
+    )
+    assert out["pending"] == 1 and out["resolved"] == 1
+    assert [r["request_id"] for r in a.resolved] == ["r1"]
+    assert a.resolved[0]["decision"] == "approved"
+
+
+def test_row_workflow_id_accepts_json_string_payload():
+    row = {"request_id": "r1", "run_id": "wf-x",
+           "payload": json.dumps({"workflow_id": "wf-y", "gate_node": "dispatch"})}
+    assert hitl_reconcile.row_workflow_id(row) == "wf-y"
+    assert hitl_reconcile.row_gate_node(row) == "dispatch"
+
+
+def test_row_workflow_id_falls_back_to_run_id():
+    assert hitl_reconcile.row_workflow_id({"run_id": "wf-z", "payload": {}}) == "wf-z"
+
+
+# ---------------- 4. doctor line ----------------
+
+def test_doctor_hitl_line_warns_over_threshold():
+    line = cli._hitl_backlog_line([{}] * 858, 25)
+    assert line.startswith("WARN:")
+    assert "pending=858" in line and "threshold=25" in line
+
+
+def test_doctor_hitl_line_ok_under_threshold():
+    assert cli._hitl_backlog_line([{}] * 3, 25).startswith("OK:")
+
+
+def test_doctor_hitl_line_fail_soft_when_unreachable():
+    assert cli._hitl_backlog_line(None, 25).startswith("WARN:")
+
+
+# ---------------- 5. CLI reconcile command ----------------
+
+def _run_reconcile(monkeypatch, capsys, rows, phases, *, apply=False, limit=None):
+    fake = _FakeAttestor(rows)
+    monkeypatch.setattr(cli, "_reconcile_attestor", lambda _p: fake)
+    monkeypatch.setattr(cli, "_make_phase_lookup", lambda _p: _phases(phases))
+    rc = cli._cmd_eights_hitl_reconcile(argparse.Namespace(
+        project=None, apply=apply, limit=limit))
+    return rc, json.loads(capsys.readouterr().out), fake
+
+
+def test_cli_reconcile_dry_run(monkeypatch, capsys):
+    rc, out, fake = _run_reconcile(
+        monkeypatch, capsys,
+        [_row("r1", "wf-term"), _row("r2", "wf-live")],
+        {"wf-term": "surfaced", "wf-live": "dispatch"},
+    )
+    assert rc == 0
+    assert out["mode"] == "dry-run"
+    assert out["pending"] == 2 and out["terminal"] == 1 and out["active"] == 1
+    assert out["resolved"] == 0
+    assert fake.resolved == []
+
+
+def test_cli_reconcile_apply(monkeypatch, capsys):
+    rc, out, fake = _run_reconcile(
+        monkeypatch, capsys,
+        [_row("r1", "wf-term"), _row("r2", "wf-live")],
+        {"wf-term": "surfaced", "wf-live": "dispatch"},
+        apply=True,
+    )
+    assert rc == 0
+    assert out["mode"] == "apply"
+    assert out["resolved"] == 1
+    assert [r["request_id"] for r in fake.resolved] == ["r1"]
+
+
+def test_cli_reconcile_registered_in_dispatch_table():
+    parser_out = cli.main.__doc__  # keep import-time coverage honest
+    assert parser_out is None or isinstance(parser_out, str)
+    with pytest.raises(SystemExit):
+        cli.main(["eights-hitl-reconcile", "--help"])
+
+
+# ---------------- 6. reap → resolve ----------------
+
+def test_reap_apply_resolves_reaped_workflow_rows(monkeypatch, capsys, tmp_path):
+    """`hydra reap --apply` must close the ledger rows it just orphaned."""
+    fake = _FakeAttestor([_row("r1", "wf-a"), _row("r2", "wf-b")])
+    monkeypatch.setattr(cli, "_reconcile_attestor", lambda _p: fake)
+
+    class _Snap:
+        def __init__(self, values):
+            self.values = values
+            self.created_at = "2020-01-01T00:00:00+00:00"
+
+    class _Sup:
+        def get_state(self, config):
+            return _Snap({"phase": "approval", "root_goal": "g"})
+
+        def update_state(self, config, patch):
+            return None
+
+    monkeypatch.setattr(cli, "_NullDispatcher", cli._NullDispatcher)
+    monkeypatch.setattr("hydra_core.supervisor.build_supervisor",
+                        lambda **kw: _Sup())
+    monkeypatch.setattr(cli, "emit", lambda *a, **k: None)
+
+    # Point reap at a checkpoint db containing exactly wf-a and wf-b.
+    import sqlite3
+    cp_db = tmp_path / "checkpoints.db"
+    conn = sqlite3.connect(cp_db)
+    conn.execute("CREATE TABLE checkpoints (thread_id TEXT)")
+    conn.executemany("INSERT INTO checkpoints VALUES (?)",
+                     [("wf-a",), ("wf-b",)])
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("HYDRA_CHECKPOINT_DB", str(cp_db))
+
+    rc = cli._cmd_reap(argparse.Namespace(
+        project=str(tmp_path), older_than_hours=24.0, apply=True))
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert sorted(out["reaped"]) == ["wf-a", "wf-b"]
+    assert out["eights_hitl"]["resolved"] == 2
+    assert {r["request_id"] for r in fake.resolved} == {"r1", "r2"}
+    assert all(r["note"] == "workflow terminal: surfaced" for r in fake.resolved)
+
+
+def test_reap_dry_run_resolves_nothing(monkeypatch, capsys, tmp_path):
+    fake = _FakeAttestor([_row("r1", "wf-a")])
+
+    class _Sup:
+        def get_state(self, config):
+            return None
+
+    monkeypatch.setattr(cli, "_reconcile_attestor", lambda _p: fake)
+    monkeypatch.setattr("hydra_core.supervisor.build_supervisor",
+                        lambda **kw: _Sup())
+    monkeypatch.setenv("HYDRA_CHECKPOINT_DB", str(tmp_path / "absent.db"))
+    rc = cli._cmd_reap(argparse.Namespace(
+        project=str(tmp_path), older_than_hours=24.0, apply=False))
+    assert rc == 0
+    assert fake.resolved == []
+
+
+# ---------------- 7. resume → resolve ----------------
+
+def _mock_sup(workflow_id: str, pending: dict):
+    from unittest.mock import MagicMock
+    sup = MagicMock()
+    sup.get_state.return_value = MagicMock(values={
+        "pending_hitl": pending,
+        "phase": "approval",
+        "budget": {"budget_usd": 50.0, "spent_usd": 0.0,
+                   "token_limit": 200000, "spent_tokens": 0},
+    })
+    sup.update_state.return_value = None
+    sup.invoke.return_value = {"phase": "done"}
+    return sup
+
+
+def _resume(monkeypatch, tmp_path, action, option=None):
+    from unittest.mock import patch as _patch
+    seen: list[dict] = []
+    monkeypatch.setattr(
+        cli, "_resolve_eights_hitl_for_workflow",
+        lambda project, wf, **kw: (seen.append({"wf": wf, **kw}),
+                                   {"resolved": 1, "failed": 0, "pending": 1})[1],
+    )
+    wf = "wf-resume-e2-17"
+    pending = {"workflow_id": wf, "gate_node": "approval", "reason": "high_risk"}
+    with _patch("hydra_core.supervisor.build_supervisor",
+                return_value=_mock_sup(wf, pending)), \
+         _patch("hydra_core.supervisor._PurePythonRunner", type(None)):
+        cli._cmd_resume_locked(
+            argparse.Namespace(project=str(tmp_path), live=False, verbose=False),
+            tmp_path, wf, action, option)
+    return seen
+
+
+def test_resume_approve_resolves_that_gate_row(monkeypatch, tmp_path, capsys):
+    seen = _resume(monkeypatch, tmp_path, "approve")
+    capsys.readouterr()
+    assert len(seen) == 1
+    assert seen[0]["gate_node"] == "approval"
+    assert seen[0]["decision"] == "approved"
+    assert seen[0]["note"] == "hydra resume: approve"
+
+
+def test_resume_reject_resolves_as_terminal(monkeypatch, tmp_path, capsys):
+    seen = _resume(monkeypatch, tmp_path, "reject")
+    capsys.readouterr()
+    assert seen[0]["decision"] == "rejected"
+    assert seen[0]["note"] == "workflow terminal: surfaced"
+
+
+def test_resume_abort_option_resolves_as_terminal(monkeypatch, tmp_path, capsys):
+    seen = _resume(monkeypatch, tmp_path, "approve", option="abort")
+    capsys.readouterr()
+    assert seen[0]["decision"] == "rejected"
+    assert seen[0]["note"] == "workflow terminal: surfaced"
+
+
+def test_resolve_eights_hitl_for_workflow_never_raises(monkeypatch):
+    def _boom(_project):
+        raise RuntimeError("no dispatcher")
+
+    monkeypatch.setattr(cli, "_reconcile_attestor", _boom)
+    out = cli._resolve_eights_hitl_for_workflow(
+        cli.Path("."), "wf-1", note="workflow terminal: surfaced")
+    assert out["resolved"] == 0
+    assert out["unavailable"] is True


### PR DESCRIPTION
Hydra filed a `hydra_gate` HITL request with TheEights on every gate it raised, but never set `expires_at` and never resolved the row when the workflow went terminal. The 2026-09-01 E2E trace measured 858 pending rows across 763 distinct workflows, all terminal.

## What changed

- **Expiry.** `EightsAttestor.hitl_request` now always emits `expires_at` = now + `HYDRA_HITL_EXPIRY_HOURS` (default 24h, the hitl-protocol wait window). A caller-supplied expiry still wins.
- **Adapter.** New `hitl_list` (returns the JSON array `_call` would discard; `None` when the daemon is silent) and `hitl_resolve` (fail-soft, spooled, carrying the WS-AUTH `hitl.resolve` capability token the daemon requires).
- **Reconcile logic.** New `hydra_core/eights/hitl_reconcile.py` holds the pure matching: payload to workflow_id/gate_node, per-workflow resolve, and the sweep.
- **Terminal transitions close the row.** `hydra resume` (scoped to the resolved gate identity, mirroring the spool prune), the `abort` option, and `hydra reap --apply` (one `hitl.list` for the whole sweep). Resume reuses its existing dispatcher, so a non-live resume no-ops rather than starting the daemon mid-resume.
- **Doctor.** A separate HITL backlog line, warning above `HYDRA_HITL_PENDING_THRESHOLD` (default 25) and degrading open when eights is unreachable. Not folded into the spool-depth line.
- **CLI.** `hydra eights-hitl-reconcile [--apply] [--limit N]` sweeps the pending queue against the checkpoint store and resolves only terminal/unknown workflows' rows. Active gates are never touched. Dry-run by default, printing `{pending, terminal, unknown, active, resolved}`.

Docs updated: hitl-protocol SKILL.md, ARCHITECTURE.md section 7, README.

## Tests

| Suite | Result |
|---|---|
| `tests/test_hitl_expiry_reconcile.py` (new) | 32 passed |
| `-k "hitl or reap or doctor or reconcile"` | 99 passed |
| full suite | 1709 passed, 4 skipped, 2 failed |

The 2 failures (`test_active_source_packs_are_host_attended_native_plugins`, `test_operator_skills_use_canonical_namespace_without_project_duplicates`) are pre-existing and reproduce on a clean stashed tree in this worktree: the five `marketing-*` squad packs are filesystem symlinks into the MarketBliss checkout, and `.claude/agents` is absent, in a `git worktree` checkout. Unrelated to this change.

No test here reaches the real TheEights daemon; every one stubs the dispatcher.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
