### PR TITLE
E2-25: versioned rubric resolution + explicit fallback in attended judge

### DIFF
--- a/hydra_core/host_bridge.py
+++ b/hydra_core/host_bridge.py
@@ -51,7 +51,9 @@ from .squad_node import (
     _pp_gate_type,
     _pp_inner,
     _pp_ok,
-    _rubric_md,
+    _default_rubric_id,
+    _resolve_rubric_id,
+    _rubric_md_ex,
     _run_smoke,
     _worktree_dirty_set,
 )
@@ -1494,7 +1496,7 @@ def begin_stage(
     project_path: str,
     request_text: str,
     model_tier: str | None = None,
-    judge_rubric_id: str = "rfc-2119-normative",
+    judge_rubric_id: str | None = None,
     project_root: str | Path | None = None,
     task_id: str | None = None,
     isolate: bool = True,
@@ -1513,6 +1515,14 @@ def begin_stage(
     """
     # Browser isolation parity with the headless driver (PP-BV-ISO).
     os.environ.setdefault("PP_BROWSER_ENGINE", "playwright")
+    # E2-25: an attended stage is always kind="code", so its default rubric is
+    # the code rubric. It used to default to the SPEC rubric
+    # `rfc-2119-normative`, which pp's gates.ts maps only to gate_type="spec" —
+    # and whose body no registry served for the unversioned id, so every code
+    # stage was silently judged on a generic one-liner while the ledger recorded
+    # the spec rubric's name.
+    judge_rubric_id = judge_rubric_id or _default_rubric_id(
+        _pp_gate_type("code", "code_style"))
     cm = dispatcher.call_mcp
 
     st = _raise_on_error_payload(
@@ -1732,16 +1742,32 @@ def _apply_generate(dispatcher: Dispatcher, cursor: dict[str, Any],
     except Exception:  # noqa: BLE001
         gate_dec = {}
     required_cross = bool(gate_dec.get("required_cross_vendor", True))
-    gate_rubric = str(gate_dec.get("rubric_id") or cursor["judge_rubric_id"])
+    # E2-25: pp and Hydra both key rubrics by an immutable `@N`; a bare base id
+    # resolves to the highest registered version before it reaches the judge or
+    # the ledger. An id nothing registers is traced, not silently accepted.
+    requested_rubric = str(gate_dec.get("rubric_id") or cursor["judge_rubric_id"])
+    gate_rubric = _resolve_rubric_id(
+        dispatcher, requested_rubric,
+        lambda base: _trace(cursor, "attended.rubric_unresolved", {
+            "stage_id": stage_id, "requested": base}))
     # producer is "claude": a sanctioned same-vendor Claude judge is allowed only
     # when cross-vendor is NOT required; otherwise the host must spawn the
     # cross-vendor judge (codex/agy critique).
     judge_agent = "judge-cross-vendor" if required_cross else "judge-same-vendor"
-    rubric_body = _rubric_md(gate_rubric)
+    rubric_body, rubric_fallback = _rubric_md_ex(gate_rubric, dispatcher)
+    if rubric_fallback:
+        # The judge is about to see the GENERIC rubric, not the named one. Say so
+        # here, in the host_action, and in the verdict metadata — the ledger must
+        # never carry a rubric id whose body was not the one applied.
+        _trace(cursor, "attended.rubric_fallback", {
+            "stage_id": stage_id, "requested": requested_rubric,
+            "effective": gate_rubric,
+        })
     judge_text = _judge_artifact_text(
         work_path, sorted(run_changed), gen_text)
 
     cursor["gate_rubric"] = gate_rubric
+    cursor["gate_rubric_fallback"] = rubric_fallback
     cursor["required_cross"] = required_cross
     cursor["state"] = "await_judge"
     # LV-8: scope the call_key with run_id + stage_id, not just the generate
@@ -1774,13 +1800,18 @@ def _apply_generate(dispatcher: Dispatcher, cursor: dict[str, Any],
         "call_key": judge_call_key,
         "agent_type": judge_agent,
         "rubric_id": gate_rubric,
+        "rubric_fallback": rubric_fallback,
         "required_cross_vendor": required_cross,
         "artifact_text": judge_text,
         "rubric_md": rubric_body,
         "cwd": work_path,
         "instructions": (
             f"Spawn the visible `{judge_agent}` subagent to judge the diff "
-            f"against rubric {gate_rubric}. Then call submit-host-result with "
+            f"against rubric {gate_rubric}"
+            + (" (NOTE: no registry served this rubric's body — `rubric_md` "
+               "below is the GENERIC fallback text, judge against that)"
+               if rubric_fallback else "")
+            + ". Then call submit-host-result with "
             "{call_key, result:{outcome:pass|revise|fail, critique_md, "
             "judge_producer, judge_model_id, score_json, cost_usd}}."),
     }
@@ -1868,6 +1899,12 @@ def _apply_judge(dispatcher: Dispatcher, cursor: dict[str, Any],
     score_json["_attended"] = True
     if degraded:
         score_json["_judge_degraded"] = True
+    # E2-25: the effective rubric travels with the verdict. `_rubric_fallback`
+    # marks a verdict whose named rubric body was NOT the one the judge applied,
+    # so an auditor reading the pp ledger can tell the two cases apart.
+    score_json["_rubric_id"] = gate_rubric
+    if cursor.get("gate_rubric_fallback"):
+        score_json["_rubric_fallback"] = True
 
     # Finding 2: track whether the outcome change is an infra failure (F31 /
     # F26+M8) vs a genuine artifact defect.  Infra failures must surface
@@ -1981,6 +2018,7 @@ def _apply_judge(dispatcher: Dispatcher, cursor: dict[str, Any],
 
     _trace(cursor, "attended.verdict", {
         "stage_id": cursor["stage_id"], "rubric_id": gate_rubric,
+        "rubric_fallback": bool(cursor.get("gate_rubric_fallback")),
         "attempt_id": attempt_id, "producer": producer,
         "judge_producer": judge_producer, "outcome": outcome,
         "cross_vendor": cross_vendor, "generate_index": gen_idx,

--- a/hydra_core/judge/registry.py
+++ b/hydra_core/judge/registry.py
@@ -688,6 +688,45 @@ _register(Rubric(
 ))
 
 
+# ---------- engineering / code ----------
+#
+# pair-programmer's registry (daemon/src/rubrics/registry.ts) ships NO rubric of
+# kind "code": its gates.ts::pickDefaultRubric returns null for the code_style /
+# lint_class gate types, which is why Hydra's engineering stages fell through to
+# the spec rubric `rfc-2119-normative`. This is the missing code-quality rubric,
+# registered locally so a code gate is judged on code criteria rather than on
+# RFC-2119 normative-language criteria (finding E2-25).
+
+_register(Rubric(
+    rubric_id="code-change-quality@1",
+    kind="code",
+    body_md=(
+        "# Code Change Quality (v1)\n"
+        "Judge a code diff on what the change actually does, not on prose style.\n"
+        "- **requirement_fidelity** (0-5): the change implements the stated "
+        "request — no more, no less; out-of-scope edits count against it.\n"
+        "- **correctness** (0-5): the logic is right for the stated inputs, "
+        "including boundary and error paths.\n"
+        "- **regression_safety** (0-5): existing behavior and public contracts "
+        "are preserved; nothing silently changes for existing callers.\n"
+        "- **test_evidence** (0-5): the change is covered by tests that would "
+        "fail without it, or the absence of tests is justified.\n"
+        "- **error_handling** (0-5): failures are surfaced, not swallowed; no "
+        "bare except that masks a real error.\n"
+        "- **readability** (0-5): names, structure, and comments explain the "
+        "non-obvious; no dead or duplicated code introduced.\n"
+        "- **security_hygiene** (0-5): no injected secrets, unvalidated input "
+        "paths, or new command/SQL/path-traversal surface.\n"
+        "Pass requires requirement_fidelity, correctness and regression_safety "
+        "all >=3, and no dimension at 0.\n"
+    ),
+    score_dimensions=(
+        "requirement_fidelity", "correctness", "regression_safety",
+        "test_evidence", "error_handling", "readability", "security_hygiene",
+    ),
+))
+
+
 def get_rubric(rubric_id: str) -> Rubric:
     if rubric_id not in _REGISTRY:
         raise KeyError(f"Unknown rubric: {rubric_id}. Known: {sorted(_REGISTRY)}")

--- a/hydra_core/judge/rubric_resolution.py
+++ b/hydra_core/judge/rubric_resolution.py
@@ -1,0 +1,264 @@
+"""Rubric id resolution + body lookup, shared by both engineering stage loops.
+
+Finding E2-25. Both the attended driver (``hydra_core.host_bridge``) and the
+headless driver (``hydra_core.squad_node``) used to hand a judge the *unversioned*
+id ``rfc-2119-normative`` and then look its body up in a registry that only
+serves versioned ids. The lookup missed, the judge silently received a generic
+one-line rubric, and the ledger still recorded ``rubric_id=rfc-2119-normative``.
+Two defects, both fixed here:
+
+1. **Version resolution.** Rubric registries (Hydra's
+   ``hydra_core.judge.registry`` and pair-programmer's
+   ``daemon/src/rubrics/registry.ts``) key every rubric by an immutable
+   ``<base>@<N>`` id. :func:`resolve_rubric_id` turns a base id into the highest
+   registered ``@N``, leaves an already-versioned id alone, and reports an
+   unresolved base to the caller instead of pretending it resolved.
+
+2. **Gate-typed defaults.** A *code* gate must not default to the *spec* rubric.
+   :func:`default_rubric_id` mirrors pair-programmer's
+   ``gates.ts::pickDefaultRubric`` for the gate types pp covers, and fills pp's
+   gap for the code-shaped gate types (pp returns ``null`` there) with Hydra's
+   local ``code-change-quality`` rubric.
+
+When a body genuinely cannot be resolved, :func:`rubric_body` returns the generic
+fallback text *and says so*, so the caller can flag the verdict rather than
+ledger an id whose body was never used.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import threading
+from typing import Any, Callable, Protocol
+
+_log = logging.getLogger(__name__)
+
+#: The rubric text used when no registry can serve a body. Kept verbatim from
+#: the pre-E2-25 ``squad_node._rubric_md`` fallback so existing traces compare.
+GENERIC_FALLBACK_BODY = (
+    "Evaluate the change for correctness, adherence to the stated request, "
+    "and absence of regressions. Output outcome (pass/revise/fail), a "
+    "critique, and per-dimension scores."
+)
+
+#: Hydra-local code-quality rubric (see ``judge/registry.py``). pp has no
+#: rubric of kind "code"; this fills that hole for code-shaped gates.
+CODE_RUBRIC_BASE = "code-change-quality"
+
+#: Gate type -> default rubric BASE id (unversioned; resolved at call time).
+#:
+#: The spec/design/contract/security rows mirror pair-programmer
+#: ``daemon/src/orchestrator/gates.ts::pickDefaultRubric``. The code-shaped rows
+#: (code_style / lint_class / docs_polish) are where pp returns ``null`` — Hydra
+#: fills them with the local code rubric rather than inheriting the spec rubric.
+DEFAULT_RUBRIC_BY_GATE_TYPE: dict[str, str] = {
+    "spec": "rfc-2119-normative",
+    "design": "c4-system-context",
+    "contract": "openapi-3.1-stability",
+    "security": "owasp-asvs-l1",
+    "code_style": CODE_RUBRIC_BASE,
+    "lint_class": CODE_RUBRIC_BASE,
+    "docs_polish": CODE_RUBRIC_BASE,
+}
+
+_VERSIONED_RE = re.compile(r"@\d+$")
+
+
+class Dispatcher(Protocol):  # pragma: no cover - structural typing only
+    def call_mcp(self, server: str, tool: str, args: dict[str, Any],
+                 squad_id: str | None = ...) -> Any: ...
+
+
+def default_rubric_id(gate_type: str | None) -> str:
+    """Default rubric BASE id for a pp gate type. Unknown gate types are treated
+    as code-shaped, matching ``_pp_gate_type``'s own ``code_style`` default."""
+    return DEFAULT_RUBRIC_BY_GATE_TYPE.get(gate_type or "", CODE_RUBRIC_BASE)
+
+
+def is_versioned(rubric_id: str) -> bool:
+    return bool(_VERSIONED_RE.search(rubric_id or ""))
+
+
+# --------------------------------------------------------------------------- #
+# Version index (base -> highest @N), cached per process                       #
+# --------------------------------------------------------------------------- #
+
+_cache_lock = threading.Lock()
+_pp_versions: dict[str, int] | None = None
+
+
+def reset_rubric_cache() -> None:
+    """Drop the cached pp rubric list (tests, and a pp daemon restart)."""
+    global _pp_versions
+    with _cache_lock:
+        _pp_versions = None
+
+
+def _split(rubric_id: str) -> tuple[str, int] | None:
+    base, _, ver = (rubric_id or "").rpartition("@")
+    if not base or not ver.isdigit():
+        return None
+    return base, int(ver)
+
+
+def _merge(index: dict[str, int], rubric_id: str) -> None:
+    parts = _split(rubric_id)
+    if parts is None:
+        return
+    base, ver = parts
+    if ver > index.get(base, -1):
+        index[base] = ver
+
+
+def _local_versions() -> dict[str, int]:
+    """Highest ``@N`` per base id in Hydra's own rubric registry."""
+    index: dict[str, int] = {}
+    try:
+        from .registry import list_rubrics
+        for r in list_rubrics():
+            _merge(index, r.rubric_id)
+    except Exception:  # noqa: BLE001 — a registry import failure is not fatal
+        _log.warning("hydra rubric registry unreadable during id resolution",
+                     exc_info=True)
+    return index
+
+
+def _pp_rows(payload: Any) -> list[dict[str, Any]]:
+    """Unwrap ``list_rubrics`` out of pp's ``{status, result}`` MCP envelope.
+
+    pp returns a bare array; the gateway may wrap it under ``result`` and/or
+    ``rubrics``. Anything else yields no rows (and therefore no resolution)."""
+    seen: set[int] = set()
+    node = payload
+    for _ in range(4):
+        if isinstance(node, list):
+            return [r for r in node if isinstance(r, dict)]
+        if not isinstance(node, dict) or id(node) in seen:
+            return []
+        seen.add(id(node))
+        for key in ("result", "rubrics", "data", "content"):
+            if key in node:
+                node = node[key]
+                break
+        else:
+            return []
+    return []
+
+
+def _fetch_pp_versions(dispatcher: Any, squad_id: str) -> dict[str, int]:
+    """Highest ``@N`` per base id served by pp's rubric registry. Cached on
+    success only, so a transient pp outage does not pin an empty index."""
+    global _pp_versions
+    with _cache_lock:
+        if _pp_versions is not None:
+            return _pp_versions
+    if dispatcher is None or not hasattr(dispatcher, "call_mcp"):
+        return {}
+    try:
+        payload = dispatcher.call_mcp("pp_harness", "list_rubrics", {},
+                                      squad_id=squad_id)
+    except Exception:  # noqa: BLE001 — never block a stage on rubric listing
+        _log.warning("pp_harness.list_rubrics failed; resolving rubric ids from "
+                     "the local registry only", exc_info=True)
+        return {}
+    index: dict[str, int] = {}
+    for row in _pp_rows(payload):
+        rid = row.get("id") or row.get("rubric_id")
+        if isinstance(rid, str):
+            _merge(index, rid)
+    if not index:
+        # An empty/again-unparseable list is not a durable fact about pp.
+        return {}
+    with _cache_lock:
+        _pp_versions = index
+    return index
+
+
+def resolve_rubric_id(
+    dispatcher: Any,
+    base_or_versioned: str,
+    *,
+    squad_id: str = "engineering",
+    on_unresolved: Callable[[str], None] | None = None,
+) -> str:
+    """Return a versioned ``<base>@<N>`` rubric id.
+
+    * An id that already carries ``@N`` passes through untouched — a caller that
+      pinned a version keeps it (replay determinism).
+    * A bare base id resolves to the highest ``@N`` registered for it, looking in
+      Hydra's local registry first and then in pp's registry via
+      ``pp_harness.list_rubrics`` (cached per process).
+    * A base no registry knows is returned unchanged and reported through
+      ``on_unresolved`` (``rubric_unresolved``), so the caller can trace it
+      rather than silently ledger an id it could not resolve.
+    """
+    rid = (base_or_versioned or "").strip()
+    if not rid:
+        rid = CODE_RUBRIC_BASE
+    if is_versioned(rid):
+        return rid
+    versions = dict(_fetch_pp_versions(dispatcher, squad_id))
+    for base, ver in _local_versions().items():  # local registry wins on ties
+        if ver >= versions.get(base, -1):
+            versions[base] = ver
+    ver = versions.get(rid)
+    if ver is None:
+        _log.warning("rubric_unresolved: no versioned rubric registered for "
+                     "base id %r; requesting it unversioned", rid)
+        if on_unresolved is not None:
+            try:
+                on_unresolved(rid)
+            except Exception:  # noqa: BLE001 — a trace hook must never break the loop
+                pass
+        return rid
+    return f"{rid}@{ver}"
+
+
+def rubric_body(
+    rubric_id: str,
+    dispatcher: Any = None,
+    *,
+    squad_id: str = "engineering",
+) -> tuple[str, bool]:
+    """Return ``(body_md, fallback)`` for ``rubric_id``.
+
+    Looks in Hydra's local registry, then pp's (``pp_harness.get_rubric``), and
+    only then degrades to :data:`GENERIC_FALLBACK_BODY` with ``fallback=True``.
+    ``fallback=True`` means the judge did NOT see the named rubric, and callers
+    must say so rather than record the id as if it had been applied.
+    """
+    if not rubric_id:
+        return GENERIC_FALLBACK_BODY, True
+    try:
+        from .registry import get_rubric
+        return get_rubric(rubric_id).body_md, False
+    except Exception:  # noqa: BLE001 — a local miss is expected for pp-owned ids
+        pass
+    if dispatcher is not None and hasattr(dispatcher, "call_mcp"):
+        try:
+            payload = dispatcher.call_mcp(
+                "pp_harness", "get_rubric", {"id": rubric_id}, squad_id=squad_id)
+            body = _pp_body(payload)
+            if body:
+                return body, False
+        except Exception:  # noqa: BLE001 — never block the loop on a registry RPC
+            _log.warning("pp_harness.get_rubric(%r) failed", rubric_id,
+                         exc_info=True)
+    return GENERIC_FALLBACK_BODY, True
+
+
+def _pp_body(payload: Any) -> str:
+    """Pull the markdown body out of pp's ``get_rubric`` envelope."""
+    node = payload
+    for _ in range(4):
+        if not isinstance(node, dict):
+            return ""
+        for key in ("markdown", "body_md", "body"):
+            val = node.get(key)
+            if isinstance(val, str) and val.strip():
+                return val
+        nxt = node.get("result", node.get("rubric"))
+        if nxt is None or nxt is node:
+            return ""
+        node = nxt
+    return ""

--- a/hydra_core/squad_node.py
+++ b/hydra_core/squad_node.py
@@ -972,17 +972,17 @@ def _drive_generate(
     return gen, "codex"
 
 
-def _rubric_md(rubric_id: str) -> str:
+def _rubric_md_ex(rubric_id: str, dispatcher: Any = None) -> tuple[str, bool]:
+    """``(body_md, fallback)`` for the judge. ``fallback=True`` means no registry
+    served the named rubric and the judge is getting the generic text instead —
+    the caller MUST surface that rather than ledger the id as applied (E2-25)."""
+    from .judge.rubric_resolution import rubric_body
+    return rubric_body(rubric_id, dispatcher, squad_id="engineering")
+
+
+def _rubric_md(rubric_id: str, dispatcher: Any = None) -> str:
     """Resolve a rubric body for the judge; degrade to a minimal rubric."""
-    try:
-        from .judge.registry import get_rubric
-        return get_rubric(rubric_id).body_md
-    except Exception:  # noqa: BLE001 — never block the loop on a registry miss
-        return (
-            "Evaluate the change for correctness, adherence to the stated request, "
-            "and absence of regressions. Output outcome (pass/revise/fail), a "
-            "critique, and per-dimension scores."
-        )
+    return _rubric_md_ex(rubric_id, dispatcher)[0]
 
 
 # pp's gate_eligible_judges accepts a STRICT gate_type enum; start_stage accepts
@@ -1002,6 +1002,20 @@ def _pp_gate_type(kind: str, gate_type: str | None = None) -> str:
     if gate_type in _PP_GATE_TYPES:
         return gate_type  # already a valid pp gate type
     return _PP_GATE_TYPE_BY_KIND.get(kind, "code_style")
+
+
+def _default_rubric_id(gate_type: str | None) -> str:
+    """Gate-typed default rubric BASE id (E2-25). See judge/rubric_resolution."""
+    from .judge.rubric_resolution import default_rubric_id
+    return default_rubric_id(gate_type)
+
+
+def _resolve_rubric_id(dispatcher: Any, rubric_id: str,
+                       on_unresolved: Any = None) -> str:
+    """Turn a base rubric id into its highest registered ``@N`` (E2-25)."""
+    from .judge.rubric_resolution import resolve_rubric_id
+    return resolve_rubric_id(dispatcher, rubric_id, squad_id="engineering",
+                             on_unresolved=on_unresolved)
 
 
 def _judge_artifact_text(
@@ -1109,7 +1123,7 @@ def _drive_pp_stage_loop(
     project_path: str,
     request_text: str,
     model_tier: str | None = None,
-    judge_rubric_id: str = "rfc-2119-normative",
+    judge_rubric_id: str | None = None,
     workflow_id: str | None = None,
     invoke_mode: str | None = None,
     # MU16: optional budget state for pre-operation gates (fleet or global).
@@ -1144,6 +1158,11 @@ def _drive_pp_stage_loop(
     F18: ``invoke_mode="pp_best_of"`` implies N=3 when HYDRA_BEST_OF_N is unset.
     An explicit HYDRA_BEST_OF_N always wins over the invoke_mode default.
     """
+    # E2-25: this stage is always kind="code", so its default rubric is the code
+    # rubric, NOT the spec rubric `rfc-2119-normative` that used to be hardcoded
+    # here (pp's gates.ts maps only gate_type="spec" to that one).
+    judge_rubric_id = judge_rubric_id or _default_rubric_id(
+        _pp_gate_type("code", "code_style"))
     # F18: explicit env wins; invoke_mode="pp_best_of" implies N=3 as fallback.
     _effective_n = _best_of_n() or (3 if invoke_mode == "pp_best_of" else None)
     if _effective_n:
@@ -1202,7 +1221,10 @@ def _drive_pp_stage_loop(
         attempt_id: str | None = None
         outcome: str | None = None
         critique_md = ""
-        rubric_body = _rubric_md(judge_rubric_id)
+        # Preload; the per-attempt gate decision below re-resolves and overwrites
+        # both of these before the judge ever sees them.
+        rubric_body, rubric_fallback = _rubric_md_ex(
+            _resolve_rubric_id(dispatcher, judge_rubric_id), dispatcher)
         gen_failed = False
 
         # Reflexion ×1 → at most two attempts.
@@ -1333,8 +1355,19 @@ def _drive_pp_stage_loop(
             except Exception:  # noqa: BLE001 — never block the loop on a policy miss
                 gate_dec = {}
             required_cross = bool(gate_dec.get("required_cross_vendor", True))
-            gate_rubric = str(gate_dec.get("rubric_id") or judge_rubric_id)
-            rubric_body = _rubric_md(gate_rubric)
+            # E2-25: pp's registries key rubrics by an immutable `@N`; request the
+            # resolved version and say so when no registry served the body.
+            _requested_rubric = str(gate_dec.get("rubric_id") or judge_rubric_id)
+            gate_rubric = _resolve_rubric_id(
+                dispatcher, _requested_rubric,
+                lambda base: _trace("engineering.rubric_unresolved",
+                                    {"stage_id": stage_id, "requested": base}))
+            rubric_body, rubric_fallback = _rubric_md_ex(gate_rubric, dispatcher)
+            if rubric_fallback:
+                _trace("engineering.rubric_fallback", {
+                    "stage_id": stage_id, "requested": _requested_rubric,
+                    "effective": gate_rubric,
+                })
 
             # The judge reads the REAL diff (verbatim code), not just the
             # generator's prose summary — a condensed summary causes false gate
@@ -1383,6 +1416,10 @@ def _drive_pp_stage_loop(
                 "cross_vendor" if required_cross else "same_vendor")
             if degraded:
                 score_json["_judge_degraded"] = True
+            # E2-25: never ledger a rubric id whose body the judge never saw.
+            score_json["_rubric_id"] = gate_rubric
+            if rubric_fallback:
+                score_json["_rubric_fallback"] = True
 
             # F26+M8: capture record_verdict success; failure on pass → downgrade.
             _rv_ok = True
@@ -1611,7 +1648,7 @@ def _rank_key(outcome: str, score: dict[str, Any], smoke_status: str) -> float:
 def _drive_best_of_loop(
     dispatcher: Dispatcher, *, run_id: str, project_path: str, request_text: str,
     n: int, model_tier: str | None = None,
-    judge_rubric_id: str = "rfc-2119-normative", workflow_id: str | None = None,
+    judge_rubric_id: str | None = None, workflow_id: str | None = None,
     # MU16: optional budget state + repo_id for pre-candidate gates.
     # None = no gate (unit tests / callers that don't thread state).
     state: "HydraState | None" = None,
@@ -1627,6 +1664,9 @@ def _drive_best_of_loop(
     (the caller then falls back to the single-candidate path). Fail-soft: any
     exception finalizes the run aborted (lock released)."""
     sq = "engineering"
+    # E2-25: code stage → code rubric default (not the spec rubric).
+    judge_rubric_id = judge_rubric_id or _default_rubric_id(
+        _pp_gate_type("code", "code_style"))
     os.environ.setdefault("PP_BROWSER_ENGINE", "playwright")
     cm = dispatcher.call_mcp
     out: dict[str, Any] = {
@@ -1785,8 +1825,18 @@ def _drive_best_of_loop(
             except Exception:  # noqa: BLE001
                 gate = {}
             required_cross = bool(gate.get("required_cross_vendor", True))
-            gate_rubric = str(gate.get("rubric_id") or judge_rubric_id)
-            rubric_body = _rubric_md(gate_rubric)
+            # E2-25: versioned id + explicit fallback, same as the single path.
+            _requested_rubric = str(gate.get("rubric_id") or judge_rubric_id)
+            gate_rubric = _resolve_rubric_id(
+                dispatcher, _requested_rubric,
+                lambda base: _trace("engineering.rubric_unresolved",
+                                    {"candidate": ci_idx, "requested": base}))
+            rubric_body, rubric_fallback = _rubric_md_ex(gate_rubric, dispatcher)
+            if rubric_fallback:
+                _trace("engineering.rubric_fallback", {
+                    "candidate": ci_idx, "requested": _requested_rubric,
+                    "effective": gate_rubric,
+                })
             judge_text = _judge_artifact_text(wt, sorted(run_changed), gen_text)
             # (A) Give the judge the candidate's real execution outcome.
             judge_text = judge_text + "\n\n" + _execution_evidence_md(
@@ -1819,6 +1869,10 @@ def _drive_best_of_loop(
             score["_judge_tier"] = "cross_vendor" if required_cross else "same_vendor"
             if required_cross and not cross_vendor:
                 score["_judge_degraded"] = True
+            # E2-25: never ledger a rubric id whose body the judge never saw.
+            score["_rubric_id"] = gate_rubric
+            if rubric_fallback:
+                score["_rubric_fallback"] = True
             # F26+M8: capture record_verdict success; failure on pass → downgrade.
             _bo_rv_ok = True
             if att_id:

--- a/tests/test_rubric_resolution.py
+++ b/tests/test_rubric_resolution.py
@@ -1,0 +1,275 @@
+"""E2-25 — versioned rubric resolution, gate-typed defaults, explicit fallback.
+
+The attended bridge used to hand the judge the unversioned id
+``rfc-2119-normative`` (a *spec* rubric, on a *code* stage), fail to resolve its
+body, silently substitute a generic one-liner, and still record
+``rubric_id=rfc-2119-normative`` in the pp ledger. These tests pin the four
+properties that fix requires:
+
+1. an unversioned base resolves to the highest ``@N`` a registry serves;
+2. an already-versioned id passes through untouched (replay determinism);
+3. a registry miss surfaces ``rubric_fallback`` in the judge host_action and in
+   the recorded verdict metadata, instead of being swallowed;
+4. a code stage defaults to the code rubric, never the spec rubric.
+"""
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from hydra_core import host_bridge
+from hydra_core.judge import rubric_resolution as rr
+
+
+@pytest.fixture(autouse=True)
+def _clear_rubric_cache():
+    rr.reset_rubric_cache()
+    yield
+    rr.reset_rubric_cache()
+
+
+class _ListDispatcher:
+    """Serves a canned pp ``list_rubrics`` / ``get_rubric`` pair."""
+
+    def __init__(self, rows, bodies=None):
+        self.rows = rows
+        self.bodies = bodies or {}
+        self.calls: list[str] = []
+
+    def call_mcp(self, server, tool, args, squad_id=None):
+        self.calls.append(tool)
+        if tool == "list_rubrics":
+            return {"status": "done", "result": list(self.rows)}
+        if tool == "get_rubric":
+            body = self.bodies.get(args.get("id"))
+            return {"status": "done",
+                    "result": {"markdown": body} if body else {}}
+        return {"status": "done", "result": {}}
+
+
+# --------------------------------------------------------------------------- #
+# resolve_rubric_id                                                            #
+# --------------------------------------------------------------------------- #
+
+def test_unversioned_base_resolves_to_highest_version():
+    disp = _ListDispatcher([
+        {"id": "web-runtime-validation@1", "kind": "contract"},
+        {"id": "web-runtime-validation@2", "kind": "contract"},
+        {"id": "rfc-2119-normative@1", "kind": "spec"},
+    ])
+    assert rr.resolve_rubric_id(disp, "web-runtime-validation") == \
+        "web-runtime-validation@2"
+    assert rr.resolve_rubric_id(disp, "rfc-2119-normative") == \
+        "rfc-2119-normative@1"
+
+
+def test_already_versioned_id_passes_through_unchanged():
+    disp = _ListDispatcher([{"id": "rfc-2119-normative@9", "kind": "spec"}])
+    # A caller that pinned @1 keeps @1 even though @9 exists — past verdicts
+    # replay against the exact rubric body they were judged with.
+    assert rr.resolve_rubric_id(disp, "rfc-2119-normative@1") == \
+        "rfc-2119-normative@1"
+    assert disp.calls == []   # no registry round-trip needed
+
+
+def test_registry_miss_returns_base_and_reports_unresolved():
+    disp = _ListDispatcher([{"id": "rfc-2119-normative@1", "kind": "spec"}])
+    seen: list[str] = []
+    out = rr.resolve_rubric_id(disp, "no-such-rubric", on_unresolved=seen.append)
+    assert out == "no-such-rubric"
+    assert seen == ["no-such-rubric"]
+
+
+def test_local_registry_resolves_without_a_dispatcher():
+    # The Hydra-local code rubric resolves even when pp is unreachable.
+    assert rr.resolve_rubric_id(None, "code-change-quality") == \
+        "code-change-quality@1"
+
+
+def test_list_rubrics_is_cached_per_process():
+    disp = _ListDispatcher([{"id": "rfc-2119-normative@1", "kind": "spec"}])
+    rr.resolve_rubric_id(disp, "rfc-2119-normative")
+    rr.resolve_rubric_id(disp, "rfc-2119-normative")
+    assert disp.calls.count("list_rubrics") == 1
+
+
+def test_pp_outage_is_not_cached_as_an_empty_registry():
+    class _Broken:
+        def __init__(self):
+            self.n = 0
+
+        def call_mcp(self, server, tool, args, squad_id=None):
+            self.n += 1
+            raise RuntimeError("pp daemon down")
+
+    disp = _Broken()
+    assert rr.resolve_rubric_id(disp, "rfc-2119-normative") == "rfc-2119-normative"
+    rr.resolve_rubric_id(disp, "rfc-2119-normative")
+    assert disp.n == 2   # retried rather than pinned to an empty index
+
+
+# --------------------------------------------------------------------------- #
+# rubric_body                                                                  #
+# --------------------------------------------------------------------------- #
+
+def test_body_comes_from_the_local_registry_without_fallback():
+    body, fallback = rr.rubric_body("code-change-quality@1")
+    assert fallback is False
+    assert "requirement_fidelity" in body
+
+
+def test_body_falls_back_to_pp_get_rubric():
+    disp = _ListDispatcher([], bodies={"rfc-2119-normative@1": "# RFC 2119\nMUST"})
+    body, fallback = rr.rubric_body("rfc-2119-normative@1", disp)
+    assert fallback is False
+    assert "RFC 2119" in body
+
+
+def test_unknown_rubric_yields_generic_body_and_flags_fallback():
+    disp = _ListDispatcher([])
+    body, fallback = rr.rubric_body("rfc-2119-normative", disp)
+    assert fallback is True
+    assert body == rr.GENERIC_FALLBACK_BODY
+
+
+# --------------------------------------------------------------------------- #
+# gate-typed defaults                                                          #
+# --------------------------------------------------------------------------- #
+
+def test_code_gate_default_is_not_the_spec_rubric():
+    for gate_type in ("code_style", "lint_class"):
+        chosen = rr.default_rubric_id(gate_type)
+        assert chosen == rr.CODE_RUBRIC_BASE
+        assert chosen != "rfc-2119-normative"
+
+
+def test_spec_gate_keeps_the_rfc_2119_rubric():
+    assert rr.default_rubric_id("spec") == "rfc-2119-normative"
+
+
+def test_unknown_gate_type_defaults_to_the_code_rubric():
+    assert rr.default_rubric_id(None) == rr.CODE_RUBRIC_BASE
+    assert rr.default_rubric_id("something-new") == rr.CODE_RUBRIC_BASE
+
+
+# --------------------------------------------------------------------------- #
+# host_bridge wiring                                                           #
+# --------------------------------------------------------------------------- #
+
+def _git(args, cwd):
+    return subprocess.run(["git", *args], cwd=str(cwd), capture_output=True,
+                          text=True, check=False)
+
+
+def _init_repo(path):
+    _git(["init"], path)
+    _git(["config", "user.email", "t@t.test"], path)
+    _git(["config", "user.name", "Test"], path)
+    _git(["config", "commit.gpgsign", "false"], path)
+    (path / "README.md").write_text("base\n", encoding="utf-8")
+    _git(["add", "-A"], path)
+    _git(["commit", "-m", "base", "--no-verify"], path)
+
+
+class _BridgeDispatcher:
+    """Minimal pp stand-in for begin_stage → submit(generate) → judge action."""
+
+    def __init__(self, *, gate_rubric=None, rubric_rows=(), bodies=None):
+        self.calls: list[tuple[str, dict]] = []
+        self._gate_rubric = gate_rubric
+        self._rows = list(rubric_rows)
+        self._bodies = bodies or {}
+
+    def call_mcp(self, server, tool, args, squad_id=None):
+        self.calls.append((tool, dict(args)))
+        if tool == "start_stage":
+            return {"status": "done", "result": {"stage_id": "stage-1"}}
+        if tool == "record_attempt":
+            return {"status": "done", "result": {"attempt_id": "att-1"}}
+        if tool == "gate_eligible_judges":
+            res = {"required_cross_vendor": True}
+            if self._gate_rubric is not None:
+                res["rubric_id"] = self._gate_rubric
+            return {"status": "done", "result": res}
+        if tool == "list_rubrics":
+            return {"status": "done", "result": list(self._rows)}
+        if tool == "get_rubric":
+            body = self._bodies.get(args.get("id"))
+            return {"status": "done",
+                    "result": {"markdown": body} if body else {}}
+        return {"status": "done", "result": {}}
+
+    def args_for(self, tool):
+        return [a for t, a in self.calls if t == tool]
+
+
+def _run_to_judge(disp, tmp_path):
+    _init_repo(tmp_path)
+    res = host_bridge.begin_stage(
+        disp, workflow_id="wf-1", run_id="run-1", project_path=str(tmp_path),
+        request_text="implement the thing", project_root=str(tmp_path))
+    return host_bridge.submit_host_result(
+        disp, cursor_file=res["cursor_path"], call_key="generate-0",
+        result={"text": "edited foo.py", "cost_usd": 0.0,
+                "tokens_in": 1, "tokens_out": 1, "model": "claude-opus-4-8"})
+
+
+def test_attended_code_stage_judges_on_the_code_rubric(tmp_path):
+    # pp returns no rubric for a code_style gate (gates.ts pickDefaultRubric ->
+    # null), so the stage default decides — and it must be the code rubric.
+    disp = _BridgeDispatcher(gate_rubric=None)
+    res = _run_to_judge(disp, tmp_path)
+    action = res["host_action"]
+    assert action["rubric_id"] == "code-change-quality@1"
+    assert action["rubric_fallback"] is False
+    assert "requirement_fidelity" in action["rubric_md"]
+
+
+def test_attended_unversioned_gate_rubric_is_resolved(tmp_path):
+    disp = _BridgeDispatcher(
+        gate_rubric="rfc-2119-normative",
+        rubric_rows=[{"id": "rfc-2119-normative@1", "kind": "spec"}],
+        bodies={"rfc-2119-normative@1": "# RFC 2119 (v1)\nMUST/SHOULD/MAY"})
+    res = _run_to_judge(disp, tmp_path)
+    action = res["host_action"]
+    assert action["rubric_id"] == "rfc-2119-normative@1"
+    assert action["rubric_fallback"] is False
+    assert "RFC 2119" in action["rubric_md"]
+
+
+def test_attended_registry_miss_flags_fallback_in_action_and_verdict(tmp_path):
+    # No registry serves this id: the judge gets the generic body, and both the
+    # host_action and the recorded verdict must say so.
+    disp = _BridgeDispatcher(gate_rubric="ghost-rubric")
+    res = _run_to_judge(disp, tmp_path)
+    action = res["host_action"]
+    assert action["rubric_id"] == "ghost-rubric"
+    assert action["rubric_fallback"] is True
+    assert action["rubric_md"] == rr.GENERIC_FALLBACK_BODY
+
+    host_bridge.submit_host_result(
+        disp, cursor_file=res["cursor_path"], call_key=action["call_key"],
+        result={"outcome": "revise", "critique_md": "needs work",
+                "judge_producer": "codex", "judge_model_id": "gpt-x",
+                "score_json": {"correctness": 3}, "cost_usd": 0.0})
+    verdicts = disp.args_for("record_verdict")
+    assert verdicts, "record_verdict was never called"
+    score = verdicts[-1]["score_json"]
+    assert verdicts[-1]["rubric_id"] == "ghost-rubric"
+    assert score["_rubric_id"] == "ghost-rubric"
+    assert score["_rubric_fallback"] is True
+
+
+def test_attended_resolved_verdict_carries_no_fallback_flag(tmp_path):
+    disp = _BridgeDispatcher(gate_rubric=None)
+    res = _run_to_judge(disp, tmp_path)
+    host_bridge.submit_host_result(
+        disp, cursor_file=res["cursor_path"],
+        call_key=res["host_action"]["call_key"],
+        result={"outcome": "revise", "critique_md": "needs work",
+                "judge_producer": "codex", "judge_model_id": "gpt-x",
+                "score_json": {}, "cost_usd": 0.0})
+    score = disp.args_for("record_verdict")[-1]["score_json"]
+    assert score["_rubric_id"] == "code-change-quality@1"
+    assert "_rubric_fallback" not in score


### PR DESCRIPTION
## What was wrong

`host_bridge.begin_stage` defaulted `judge_rubric_id="rfc-2119-normative"` and looked the body up by that unversioned id. Every rubric registry (Hydra's `hydra_core/judge/registry.py` and pair-programmer's `daemon/src/rubrics/registry.ts`) keys rubrics by an immutable `@N`, so the lookup missed. The judge silently got a generic one-line rubric while the host_action and the pp verdict ledger still recorded `rubric_id=rfc-2119-normative`. Separately the stage is a **code** stage, and pp's `gates.ts` maps `rfc-2119-normative` only to `gate_type="spec"`.

## What changed

- **`hydra_core/judge/rubric_resolution.py` (new).** `resolve_rubric_id(dispatcher, id)` passes a versioned id through untouched (replay determinism), resolves a bare base to the highest `@N` across Hydra's local registry and pp's `list_rubrics` (cached per process, and a pp outage is not cached as an empty registry), and reports an unknown base through an `on_unresolved` hook instead of silently accepting it. `rubric_body(...)` returns `(body, fallback)` after trying the local registry then `pp_harness.get_rubric`.
- **`code-change-quality@1` rubric (new).** pp's `pickDefaultRubric` returns null for the `code_style` / `lint_class` gate types and pp's registry has no rubric of kind `code`, so a code gate had nothing to inherit but the spec rubric. `default_rubric_id` mirrors `gates.ts` for spec / design / contract / security and maps the code-shaped gate types to this rubric.
- **Both stage loops wired to one resolver.** `host_bridge` and `squad_node` (single-candidate and best-of) resolve identically. On a registry miss they emit trace `attended.rubric_fallback` / `engineering.rubric_fallback` with `{requested, effective}`, set `rubric_fallback: true` in the judge host_action (and note it in the judge instructions), and carry `_rubric_id` / `_rubric_fallback` into the `record_verdict` `score_json` metadata. No rubric `@N` body was modified.

## Tests

| Suite | Result |
|---|---|
| `tests/test_rubric_resolution.py` (new) | 16 passed |
| `-k "host_bridge or rubric or judge"` | 186 passed |
| full `python -m pytest -q` | 1693 passed, 4 skipped, 2 failed |

The two failures are the known worktree-environment ones: `test_native_pack_dispatch.py::test_active_source_packs_are_host_attended_native_plugins` and `test_claude_native_configuration.py::test_operator_skills_use_canonical_namespace_without_project_duplicates`. Both depend on the marketing symlinks and `.claude/agents`, which a linked worktree does not carry. Neither touches rubric code.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
