### PR TITLE
E2-29: garland lead agent is calliope + lead_agent existence test

### DIFF
--- a/hydra_core/native_packs.py
+++ b/hydra_core/native_packs.py
@@ -26,7 +26,7 @@ class NativePack:
 
 NATIVE_PACKS: dict[str, NativePack] = {
     "executive": NativePack("executive-suite", "executivesuite", "boardroom", "output"),
-    "garland": NativePack("rlm-creative", "rlm-creative", "brand-strategist", "RLM/output"),
+    "garland": NativePack("rlm-creative", "rlm-creative", "calliope", "RLM/output"),
     "legal-compliance": NativePack("senate", "senate", "general-counsel", "output"),
     "rlm-gaming": NativePack("rlm-gaming", "rlm-gaming", "the-director", "RLM/output"),
     "marketing-strategy": NativePack("marketbliss", "marketbliss", "marketing-supervisor", "output"),

--- a/tests/test_fable_audit_2.py
+++ b/tests/test_fable_audit_2.py
@@ -704,10 +704,11 @@ class TestResolvePackLeadAgent:
         from hydra_core.squad_loader import discover_squads
 
         packs = discover_squads(HYDRA_ROOT)
-        # garland's first gatekeeper is brand-strategist (authority: gatekeeper)
+        # garland is claude-native, so the lead comes from NATIVE_PACKS, whose
+        # lead_agent must be the RLM-Creative plugin agent name (E2-29).
         garland = packs["garland"]
         lead = _resolve_pack_lead_agent(garland)
-        assert lead == "rlm-creative:brand-strategist"
+        assert lead == "rlm-creative:calliope"
 
     def test_fallback_to_general_purpose_when_no_agents(self):
         from hydra_core.cli import _resolve_pack_lead_agent

--- a/tests/test_native_pack_dispatch.py
+++ b/tests/test_native_pack_dispatch.py
@@ -1,6 +1,7 @@
 """Regression coverage for the Claude Code-native pack handoff."""
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from uuid import uuid4
 
@@ -8,10 +9,63 @@ import pytest
 
 from hydra_core import artifact_store, host_bridge
 from hydra_core.artifact_store import ArtifactStoreError
+from hydra_core.native_packs import NATIVE_PACKS, NativePack, native_pack_root
 from hydra_core.squad_loader import discover_squads
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+_FRONTMATTER_NAME = re.compile(r"^name:\s*(.+?)\s*$", re.MULTILINE)
+
+
+def _frontmatter_name(path: Path) -> str | None:
+    """Return the ``name:`` value from *path*'s YAML frontmatter block."""
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    block = text[3:end] if end != -1 else text[3:]
+    match = _FRONTMATTER_NAME.search(block)
+    return match.group(1).strip().strip("'\"") if match else None
+
+
+def _agent_file(repo_root: Path, pack: NativePack) -> Path | None:
+    """First existing agent markdown file for *pack*'s lead agent, if any."""
+    candidates = (
+        repo_root / "plugins" / pack.plugin / "agents" / f"{pack.lead_agent}.md",
+        repo_root / ".claude" / "agents" / f"{pack.lead_agent}.md",
+    )
+    return next((c for c in candidates if c.is_file()), None)
+
+
+@pytest.mark.parametrize("slug", sorted(NATIVE_PACKS))
+def test_native_pack_lead_agent_exists_in_sibling_pack(slug: str) -> None:
+    """Every NATIVE_PACKS lead_agent must name a real agent in its pack repo.
+
+    Regression guard for E2-29: garland declared ``brand-strategist`` while
+    RLM-Creative's crew lead is ``calliope``, so attended dispatch emitted an
+    ``agent_type`` no host could spawn. Skips when the sibling checkout is
+    absent so the suite still runs on a partial workspace.
+    """
+    pack = NATIVE_PACKS[slug]
+    try:
+        repo_root = native_pack_root(slug)
+    except ValueError as exc:  # unregistered / missing / not a git checkout
+        pytest.skip(f"sibling checkout for {slug!r} unavailable: {exc}")
+
+    agents_dir = repo_root / "plugins" / pack.plugin / "agents"
+    if not agents_dir.is_dir() and not (repo_root / ".claude" / "agents").is_dir():
+        pytest.skip(f"{slug!r} pack checkout has no agents directory")
+
+    agent_file = _agent_file(repo_root, pack)
+    assert agent_file is not None, (
+        f"squad {slug!r} declares lead_agent {pack.qualified_lead_agent!r} "
+        f"but no agent markdown exists under {agents_dir}"
+    )
+    assert _frontmatter_name(agent_file) == pack.lead_agent, (
+        f"{agent_file} frontmatter name does not match lead_agent "
+        f"{pack.lead_agent!r}"
+    )
 
 
 class _NoopDispatcher:
@@ -21,7 +75,7 @@ class _NoopDispatcher:
 def test_native_squad_result_preserves_emitted_envelopes(tmp_path: Path) -> None:
     started = host_bridge.begin_squad_stage(
         workflow_id=str(uuid4()), task_id="task-1",
-        squad_slug="garland", entrypoint="claude-native", lead_agent="rlm-creative:brand-strategist",
+        squad_slug="garland", entrypoint="claude-native", lead_agent="rlm-creative:calliope",
         pack_cwd=str(tmp_path), request_text="make a brief", project_root=tmp_path,
     )
     result = host_bridge.submit_host_result(


### PR DESCRIPTION
## What

`NATIVE_PACKS` declared garland's `lead_agent` as `brand-strategist`, so `qualified_lead_agent()` returned `rlm-creative:brand-strategist` and attended dispatch emitted a `host_action.agent_type` that no host could spawn. RLM-Creative's crew lead is `plugins/rlm-creative/agents/calliope.md` (frontmatter `name: calliope`). `brand-strategist` is Hydra's plaza slug for that head, not the plugin agent name.

## Changes

- `hydra_core/native_packs.py` — garland `lead_agent` is now `calliope`.
- `tests/test_native_pack_dispatch.py` — new parametrised test over every `NATIVE_PACKS` entry. It resolves the sibling repo through `native_pack_root()` (not `squads/`), skips gracefully when the checkout or agents directory is absent, and asserts an agent markdown file for `lead_agent` exists with frontmatter `name` equal to `lead_agent`. Checks `plugins/<plugin>/agents/` then `.claude/agents/`.
- `tests/test_fable_audit_2.py` — `TestResolvePackLeadAgent::test_returns_first_gatekeeper` pinned the buggy value and is updated. `_resolve_pack_lead_agent` reads `NATIVE_PACKS` for claude-native packs, so this was a real downstream break, not a cosmetic one.

## Verification

All five sibling packs use the same layout, and every lead agent resolves with the fix in place: `executive-suite:boardroom`, `rlm-creative:calliope`, `senate:general-counsel`, `rlm-gaming:the-director`, `marketbliss:marketing-supervisor`.

`python -m pytest tests/test_native_pack_dispatch.py tests/test_claude_native_configuration.py -q`

| Result | Count |
|---|---|
| passed | 24 |
| failed | 2 |

Both failures are pre-existing and environmental, reproduced on the unmodified branch via `git stash`. They come from this worktree not materialising the `marketing-*` squad symlinks or a `.claude/agents` directory: `test_active_source_packs_are_host_attended_native_plugins` and `test_operator_skills_use_canonical_namespace_without_project_duplicates`. The 9 new parametrised cases all pass.

Broader regression run over every suite that references the affected names, `tests/test_fable_audit_2.py tests/test_cli.py tests/test_host_bridge.py tests/test_heads.py tests/test_pack_shims.py tests/test_rlm_creative_integration.py`: 254 passed, 1 skipped.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
