### PR TITLE
E2-28: squad host_action prompt carries full Hydra context

### DIFF
--- a/hydra_core/cli.py
+++ b/hydra_core/cli.py
@@ -1809,6 +1809,20 @@ def _cmd_attended_step(args) -> int:
             pack_cwd = _resolve_pack_cwd(ne_pack, project)
             lead_agent = _resolve_pack_lead_agent(ne_pack)
 
+            # E2-28: upstream context as HANDLES only (never raw artifact text
+            # across a squad boundary) — completed tasks' envelope ids plus the
+            # workflow's episodic MemoryRef keys.
+            _done_ids = set(getattr(state, "attended_completed_task_ids", []) or [])
+            _upstream_refs: list[str] = []
+            for _t in getattr(state, "tasks", []):
+                if str(_t.task_id) not in _done_ids:
+                    continue
+                _rid = getattr(_t, "result_envelope_id", None) or getattr(_t, "envelope_id", None)
+                if _rid:
+                    _upstream_refs.append(f"envelope:{_rid} ({_t.owner_squad})")
+            _upstream_refs.extend(
+                f"episodic:{k}" for k in (getattr(state, "episodic_refs", []) or []))
+
             res = host_bridge.begin_squad_stage(
                 workflow_id=wf,
                 task_id=task_id,
@@ -1818,6 +1832,16 @@ def _cmd_attended_step(args) -> int:
                 pack_cwd=pack_cwd,
                 request_text=request_text,
                 project_root=project,
+                goal=state.root_goal,
+                envelope_id=(str(ne_task.envelope_id)
+                             if getattr(ne_task, "envelope_id", None) else None),
+                upstream_refs=_upstream_refs,
+                budget_usd=state.budget.budget_usd,
+                budget_remaining_usd=state.budget.usd_remaining,
+                risk=("high" if getattr(state, "requires_human_approval", False)
+                      else "normal"),
+                priority=getattr(ne_task, "priority", None),
+                acceptance_criteria=getattr(ne_task, "acceptance_criteria", None),
             )
             emit(project, wf, "attended.step", {
                 "run_id": task_id,

--- a/hydra_core/host_bridge.py
+++ b/hydra_core/host_bridge.py
@@ -37,7 +37,7 @@ import shutil
 import stat
 import subprocess
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 import re as _re
 
@@ -2300,6 +2300,67 @@ def _finalize(dispatcher: Dispatcher, cursor: dict[str, Any], *,
     })
 
 
+def _build_squad_prompt(
+    *,
+    workflow_id: str,
+    task_id: str,
+    squad_slug: str,
+    request_text: str,
+    goal: str | None = None,
+    envelope_id: str | None = None,
+    upstream_refs: Sequence[str] | None = None,
+    budget_usd: float | None = None,
+    budget_remaining_usd: float | None = None,
+    risk: str | None = None,
+    priority: str | None = None,
+    acceptance_criteria: Sequence[str] | None = None,
+) -> str:
+    """E2-28: build the non-engineering squad host_action prompt.
+
+    Mirrors the engineering path's ``## Hydra context`` block so a squad leg is
+    reproducible from the trace alone: workflow/task identity, the root goal,
+    the task description, and the governing constraints.
+
+    ``upstream_refs`` carries MemoryRef handles / envelope ids of prior completed
+    work ONLY — never raw upstream artifact content, which must not cross a squad
+    boundary un-redacted (AGENTS.md hard rule 3).
+    """
+    _none = "(none)"
+    refs = [str(r).strip() for r in (upstream_refs or []) if str(r).strip()]
+    crit = [str(c).strip() for c in (acceptance_criteria or []) if str(c).strip()]
+
+    if budget_usd is None and budget_remaining_usd is None:
+        budget_line = "unknown"
+    elif budget_usd is None:
+        budget_line = f"{budget_remaining_usd:.2f}"
+    elif budget_remaining_usd is None:
+        budget_line = f"of {budget_usd:.2f} total"
+    else:
+        budget_line = f"{budget_remaining_usd:.2f} remaining of {budget_usd:.2f} total"
+
+    lines = [
+        "## Hydra context",
+        f"workflow_id: {workflow_id}",
+        f"task_id: {task_id}",
+        f"squad: {squad_slug}",
+        f"envelope_id: {envelope_id or _none}",
+        f"upstream_refs: {', '.join(refs) if refs else _none}",
+        "",
+        "## Goal",
+        (goal or "").strip() or _none,
+        "",
+        "## Task",
+        (request_text or "").strip() or _none,
+        "",
+        "## Constraints",
+        (f"budget_usd: {budget_line}, risk: {risk or 'unknown'}, "
+         f"priority: {priority or 'unknown'}"),
+        "acceptance_criteria: " + (_none if not crit else ""),
+    ]
+    lines.extend(f"- {c}" for c in crit)
+    return "\n".join(lines)
+
+
 def begin_squad_stage(
     *,
     workflow_id: str,
@@ -2310,6 +2371,14 @@ def begin_squad_stage(
     pack_cwd: str,
     request_text: str,
     project_root: str | Path,
+    goal: str | None = None,
+    envelope_id: str | None = None,
+    upstream_refs: Sequence[str] | None = None,
+    budget_usd: float | None = None,
+    budget_remaining_usd: float | None = None,
+    risk: str | None = None,
+    priority: str | None = None,
+    acceptance_criteria: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     """Create a lightweight cursor for an attended non-engineering squad task
     (claude-skill or agent-impersonation entrypoint).
@@ -2321,8 +2390,26 @@ def begin_squad_stage(
 
     Returns an ``awaiting_host`` step result whose ``host_action`` tells the host
     to spawn the visible pack agent subagent in ``pack_cwd``.
+
+    E2-28: ``host_action.prompt`` is the full context-bearing prompt built by
+    ``_build_squad_prompt``; the bare planner task label stays available as
+    ``host_action.task_description``.
     """
     call_key = f"squad-{task_id}-0"
+    prompt = _build_squad_prompt(
+        workflow_id=workflow_id,
+        task_id=task_id,
+        squad_slug=squad_slug,
+        request_text=request_text,
+        goal=goal,
+        envelope_id=envelope_id,
+        upstream_refs=upstream_refs,
+        budget_usd=budget_usd,
+        budget_remaining_usd=budget_remaining_usd,
+        risk=risk,
+        priority=priority,
+        acceptance_criteria=acceptance_criteria,
+    )
     cursor: dict[str, Any] = {
         "schema": CURSOR_SCHEMA,
         "kind": "squad",
@@ -2344,7 +2431,8 @@ def begin_squad_stage(
             "call_key": call_key,
             "agent_type": lead_agent,
             "cwd": pack_cwd,
-            "prompt": request_text,
+            "prompt": prompt,
+            "task_description": request_text,
             "instructions": "Run the pack agent and submit the artifact.",
         },
     }

--- a/tests/test_host_bridge.py
+++ b/tests/test_host_bridge.py
@@ -2421,3 +2421,67 @@ def test_recover_stalled_stage_already_merged_branch_reproduces_live_incident(tm
         "this is the exact data-loss shape from the live incident")
     assert (tmp_path / "important_fix.py").exists()
     assert (tmp_path / "old_feature.py").exists()
+
+
+# --------------------------------------------------------------------------- #
+# E2-28 — squad host_action prompt carries full Hydra context                  #
+# --------------------------------------------------------------------------- #
+
+def test_squad_stage_prompt_carries_hydra_context(tmp_path):
+    """The squad host_action prompt must be reproducible from the trace alone:
+    Hydra context block, root goal, task description and budget constraints."""
+    res = host_bridge.begin_squad_stage(
+        workflow_id="wf-e228", task_id="task-11", squad_slug="executive",
+        entrypoint="agent-impersonation", lead_agent="executive-suite:boardroom",
+        pack_cwd=str(tmp_path), request_text="Decompose goal + budget split",
+        project_root=str(tmp_path),
+        goal="Build Hydra Pulse, a live workflow dashboard",
+        envelope_id="env-42",
+        upstream_refs=["envelope:env-1 (executive)", "episodic:wf-e228/plan"],
+        budget_usd=20.0, budget_remaining_usd=17.5,
+        risk="high", priority="P1",
+        acceptance_criteria=["A budget split per squad", "One page of rationale"],
+    )
+    prompt = res["host_action"]["prompt"]
+    assert prompt.startswith("## Hydra context")
+    assert "workflow_id: wf-e228" in prompt
+    assert "task_id: task-11" in prompt
+    assert "squad: executive" in prompt
+    assert "envelope_id: env-42" in prompt
+    assert "envelope:env-1 (executive)" in prompt
+    assert "episodic:wf-e228/plan" in prompt
+    assert "Build Hydra Pulse, a live workflow dashboard" in prompt
+    assert "Decompose goal + budget split" in prompt
+    assert "17.50 remaining of 20.00 total" in prompt
+    assert "risk: high" in prompt
+    assert "priority: P1" in prompt
+    assert "- A budget split per squad" in prompt
+    # The bare planner label stays available for hosts that want just the task.
+    assert res["host_action"]["task_description"] == "Decompose goal + budget split"
+
+
+def test_squad_stage_prompt_degrades_without_context(tmp_path):
+    """With no optional context the prompt still carries identity + the task,
+    and marks the missing fields explicitly rather than omitting them."""
+    res = host_bridge.begin_squad_stage(
+        workflow_id="wf-bare", task_id="task-12", squad_slug="garland",
+        entrypoint="claude-skill", lead_agent="calliope",
+        pack_cwd=str(tmp_path), request_text="draft the brand brief",
+        project_root=str(tmp_path))
+    prompt = res["host_action"]["prompt"]
+    assert "workflow_id: wf-bare" in prompt
+    assert "envelope_id: (none)" in prompt
+    assert "upstream_refs: (none)" in prompt
+    assert "acceptance_criteria: (none)" in prompt
+    assert "budget_usd: unknown" in prompt
+    assert "draft the brand brief" in prompt
+    assert res["host_action"]["task_description"] == "draft the brand brief"
+
+
+def test_squad_prompt_builder_omits_raw_upstream_content():
+    """Hard rule 3: only handles cross a squad boundary, never blobs. The
+    builder has no parameter that could carry raw upstream artifact text."""
+    import inspect
+    params = set(inspect.signature(host_bridge._build_squad_prompt).parameters)
+    assert "upstream_refs" in params
+    assert not {"upstream_text", "upstream_content", "artifacts"} & params


### PR DESCRIPTION
`host_bridge.begin_squad_stage` emitted a `host_action` whose `prompt` was only the planner task label, so a non-engineering squad leg (executive, garland, marketing, legal) was not reproducible from the trace and different hosts produced different squad outputs.

## Change

- New `_build_squad_prompt` in `hydra_core/host_bridge.py` builds the same `## Hydra context` block the engineering path gets: workflow id, task id, squad slug, envelope id, upstream refs; then the root goal, the task description, and a constraints line with budget remaining/total, risk, priority and acceptance criteria.
- `begin_squad_stage` gained optional keyword args for that context and now uses the built prompt for `host_action.prompt`. The bare planner label is preserved as `host_action.task_description`.
- `hydra_core/cli.py::_cmd_attended_step` passes goal, budget, risk, priority, acceptance criteria, envelope id and upstream refs from the workflow state at the single call site.
- Upstream context crosses the squad boundary as **handles only** (`envelope:<id>`, `episodic:<key>`) — never raw artifact content, per AGENTS.md hard rule 3.

## Tests

Three new tests in `tests/test_host_bridge.py`: the populated prompt contains workflow id, goal, task description, budget, risk, priority, criteria and upstream refs; the bare prompt still carries identity and marks missing fields `(none)`/`unknown`; and the builder signature has no parameter able to carry raw upstream text.

Full suite: **1680 passed, 4 skipped, 2 failed**. Both failures (`test_operator_skills_use_canonical_namespace_without_project_duplicates`, `test_active_source_packs_are_host_attended_native_plugins`) are pre-existing worktree-environment failures — the `marketing-*` symlinked packs are absent in a worktree checkout. Verified they fail identically with the change stashed.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
