### PR TITLE
E2-22: attended approve defers engineering instead of skeleton dispatch + fake verdicts

### DIFF
--- a/hydra_core/supervisor.py
+++ b/hydra_core/supervisor.py
@@ -2170,9 +2170,26 @@ def build_supervisor(
             # it to the host strands the task as deferred_to_host instead of
             # surfacing the honest stub signal. Only agent-impersonation and
             # claude-skill (which genuinely need a host executor) are deferred.
+            # E2-22: the mirror case. An attended `hydra approve` pass re-enters
+            # this node with a NON-live dispatcher (cli's `_NullDispatcher`).
+            # Letting the mcp engineering pack through there scaffolded a
+            # skeleton pp "run" from the stub response, emitted a placeholder
+            # DECISION_RECORD, and let the NoOp judge score it (`_skeleton:true`
+            # verdicts + a Reflexion retry) for work the host had not driven
+            # yet. Defer it exactly like the native packs; the attended host
+            # drives the real stage loop through host_bridge afterwards.
+            # Offline callers that genuinely want the in-graph mcp path (unit
+            # tests with a scripted pp dispatcher) opt in explicitly by setting
+            # `allow_offline_mcp_dispatch = True` on their dispatcher.
+            _live_dispatch = getattr(dispatcher, "live_execution", False)
+            _offline_mcp_ok = getattr(
+                dispatcher, "allow_offline_mcp_dispatch", False) is True
             if (pack.entrypoint == "claude-native"
-                    or (getattr(dispatcher, "live_execution", False)
-                        and pack.entrypoint not in ("mcp", "stub"))):
+                    or (_live_dispatch
+                        and pack.entrypoint not in ("mcp", "stub"))
+                    or (not _live_dispatch
+                        and pack.entrypoint == "mcp"
+                        and not _offline_mcp_ok)):
                 emit_trace(judge_trace_root, state.workflow_id, "dispatch.deferred_to_host", {
                     "squad": pack.slug,
                     "entrypoint": pack.entrypoint,
@@ -2475,7 +2492,13 @@ def build_supervisor(
             "artifacts": artifacts,
             "verdicts": bon_verdicts,
             "tasks": _forwarded_tasks,
-            "phase": "judge_per_squad",
+            # E2-22: this key pre-declares the node the graph is about to
+            # enter. When every task was parked for the attended host there is
+            # no next node — after_dispatch ends the pass — so hold the honest
+            # "executing" instead of claiming a judge pass that will not run.
+            "phase": ("executing"
+                      if _all_tasks_deferred_to_host(state, packs)
+                      else "judge_per_squad"),
         }
 
     def _reflexion_retry(
@@ -3444,7 +3467,16 @@ def build_supervisor(
         """
         if state.hitl_return_node == "dispatch":
             return "hitl_gate_dispatch"
-        return "halt" if state.phase == "surfaced" else "judge_per_squad"
+        if state.phase == "surfaced":
+            return "halt"
+        # E2-22: dispatch parked EVERY task awaiting the attended host — there
+        # is nothing to judge and nothing to synthesize. Stop here (phase stays
+        # "executing") so the trace does not record verdicts and a synthesis
+        # for work that has not run. The host drives the real stages next and
+        # re-enters via the continuation transport.
+        if _all_tasks_deferred_to_host(state, packs):
+            return "await_host"
+        return "judge_per_squad"
 
     def after_judge_per_squad(state: HydraState) -> str:
         """F9: when judge_per_squad surfaced a resumable HITL gate, route to
@@ -3507,6 +3539,10 @@ def build_supervisor(
         "judge_per_squad": "judge_per_squad",
         "hitl_gate_dispatch": "hitl_gate_dispatch",
         "halt": "postcheck",
+        # E2-22: every task deferred to the attended host — end the graph pass
+        # here rather than judging/synthesizing work that never ran. Note this
+        # goes to END, not postcheck: postcheck would stamp phase="done".
+        "await_host": END,
     })
     # F9: hitl_gate_dispatch → dispatch (re-entry after operator approval).
     graph.add_edge("hitl_gate_dispatch", "dispatch")
@@ -3556,6 +3592,30 @@ def build_supervisor(
     return graph.compile(
         checkpointer=checkpointer,
         interrupt_before=interrupts,
+    )
+
+
+def _all_tasks_deferred_to_host(state: HydraState, packs: dict) -> bool:
+    """True when dispatch parked every task, engineering included, for the host.
+
+    E2-22. Two deliberate narrowings:
+
+    ALL, not ANY. On the live/detached path dispatch defers the non-mcp packs
+    and still runs engineering in-graph; that mixed pass must keep judging and
+    synthesizing the leg it actually executed.
+
+    At least one mcp pack. This finding is about the engineering leg being
+    parked, so the hold applies only to a pass that deferred one. A workflow
+    with no mcp squad at all keeps its existing routing — whether an all-native
+    pass should synthesize placeholder output is a separate question this fix
+    does not answer.
+    """
+    tasks = list(getattr(state, "tasks", []) or [])
+    if not tasks or not all(t.status == "deferred_to_host" for t in tasks):
+        return False
+    return any(
+        getattr(packs.get(t.owner_squad), "entrypoint", None) == "mcp"
+        for t in tasks
     )
 
 
@@ -3613,5 +3673,10 @@ class _PurePythonRunner:
                     else:
                         setattr(s, k, v)
             if s.phase in ("done", "surfaced"):
+                return s
+            # E2-22: mirror the compiled graph's "await_host" edge — a dispatch
+            # pass that parked every task for the attended host stops here
+            # instead of falling through to judge/synthesis/postcheck.
+            if name == "dispatch" and _all_tasks_deferred_to_host(s, self.packs):
                 return s
         return s

--- a/tests/test_e2_22_attended_defers_engineering.py
+++ b/tests/test_e2_22_attended_defers_engineering.py
@@ -1,0 +1,151 @@
+"""E2-22 — an attended approve pass defers engineering instead of running a
+skeleton dispatch and scoring it with fake verdicts.
+
+Live signature (workflow 8e002d23, 2026-09-01): `hydra approve <wf>` re-enters
+node_dispatch with the CLI's inert `_NullDispatcher`. Native squads were
+correctly parked (`dispatch.deferred_to_host`), but the engineering pack is
+`entrypoint: mcp`, so it fell through to `_via_mcp`. The stub response carried
+a `run_id`, so the graph recorded a placeholder engineering DECISION_RECORD,
+the NoOp judge scored it (`score_json={"_skeleton": true}`), a Reflexion retry
+produced a second identical skeleton verdict, and the pass ran on toward
+synthesis — all before the host had driven a single attended stage.
+
+The contract asserted here: on a non-live dispatcher every squad defers, the
+judge plane records nothing, and the workflow does not reach synthesis. The
+live path is unchanged and is covered by test_dispatch_defer_nonmcp.py.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hydra_core.state import HydraState
+from hydra_core.telemetry import trace_path
+
+HYDRA_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _AttendedNullDispatcher:
+    """Mirrors `hydra_core.cli._NullDispatcher` — the dispatcher an attended
+    (non-``--live``) approve pass builds. Note the absence of both
+    ``live_execution`` and ``allow_offline_mcp_dispatch``."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+        self.skill_calls: list[str] = []
+        self.prompt_calls: list[str] = []
+
+    def call_mcp(self, server, tool, args, **_kw):
+        self.calls.append((server, tool))
+        return {"status": "stub", "tool": tool, "args": args, "run_id": "stub-run"}
+
+    def spawn_subprocess(self, cmd, env=None):
+        return {"status": "stub", "stdout": "", "cmd": cmd}
+
+    def emit_claude_prompt(self, prompt, agent=None):
+        self.prompt_calls.append(agent or "")
+        return {"status": "stub", "summary": prompt[:80], "agent": agent}
+
+    def invoke_claude_skill(self, skill, args):
+        self.skill_calls.append(skill)
+        return {"status": "stub", "summary": f"would invoke /{skill}"}
+
+    def run_host_agent(self, agent_type, prompt, *, cwd=None, timeout_s=None):
+        return None
+
+    def set_squad_packs(self, packs):
+        pass
+
+
+def _run(squads: list[str], dispatcher) -> HydraState:
+    from hydra_core.supervisor import build_supervisor
+
+    runner = build_supervisor(
+        project_root=HYDRA_ROOT,
+        dispatcher=dispatcher,
+        force_pure_python=True,
+    )
+    state = HydraState(
+        root_goal="ship the widget",
+        selected_squads=list(squads),
+        # WS1-E: engineering dispatch needs a resolved target. Supplied so the
+        # planner does not surface a repo HITL before dispatch is reached.
+        target_repo_id="hydra",
+    )
+    return runner.invoke(state)
+
+
+def _trace_kinds(workflow_id) -> list[str]:
+    path = trace_path(HYDRA_ROOT, workflow_id)
+    if not path.exists():
+        return []
+    kinds: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            kinds.append(json.loads(line).get("kind", ""))
+        except json.JSONDecodeError:
+            continue
+    return kinds
+
+
+@pytest.fixture(autouse=True)
+def _no_git_harvest(monkeypatch):
+    monkeypatch.setattr("hydra_core.squad_node.harvest_pp_run_artifacts",
+                        lambda **_k: None)
+
+
+def test_attended_pass_defers_all_three_squads_and_judges_nothing():
+    disp = _AttendedNullDispatcher()
+    final = _run(["executive", "garland", "engineering"], disp)
+
+    by_squad = {t.owner_squad: t.status for t in final.tasks}
+    for slug in ("executive", "garland", "engineering"):
+        assert by_squad.get(slug) == "deferred_to_host", (
+            f"{slug} was not deferred; tasks={by_squad}"
+        )
+
+    kinds = _trace_kinds(final.workflow_id)
+    assert kinds.count("dispatch.deferred_to_host") == 3, (
+        f"expected three deferrals; trace kinds={kinds}"
+    )
+    # No fabricated verdicts, no fabricated Reflexion retry.
+    assert "judge.verdict" not in kinds
+    assert "judge.reflexion" not in kinds
+    assert final.verdicts == []
+    # No placeholder engineering DECISION_RECORD.
+    assert [e for e in final.envelopes
+            if e.get("origin_squad") == "engineering"] == []
+    # pp was never touched — the host drives the real stage loop afterwards.
+    assert ("pp_harness", "start_run") not in disp.calls
+    # And the pass held at "executing" rather than running on to synthesis.
+    assert final.phase == "executing"
+    assert final.phase not in ("synthesis", "judge_synthesis", "done")
+
+
+def test_attended_engineering_only_workflow_defers():
+    disp = _AttendedNullDispatcher()
+    final = _run(["engineering"], disp)
+
+    eng = [t for t in final.tasks if t.owner_squad == "engineering"]
+    assert eng, f"no engineering task planned; tasks={[t.owner_squad for t in final.tasks]}"
+    assert all(t.status == "deferred_to_host" for t in eng)
+    assert ("pp_harness", "start_run") not in disp.calls
+    assert final.verdicts == []
+    assert final.phase == "executing"
+
+
+def test_offline_opt_in_still_runs_the_in_graph_mcp_path():
+    """The offline skeleton path survives, but only behind the explicit flag —
+    this is what the scripted unit-test dispatchers set."""
+    disp = _AttendedNullDispatcher()
+    disp.allow_offline_mcp_dispatch = True
+    final = _run(["engineering"], disp)
+
+    assert ("pp_harness", "start_run") in disp.calls
+    eng = [t for t in final.tasks if t.owner_squad == "engineering"]
+    assert eng and all(t.status != "deferred_to_host" for t in eng)

--- a/tests/test_eights_attestation.py
+++ b/tests/test_eights_attestation.py
@@ -26,6 +26,10 @@ class _NullDispatcher:
 
 class _RecordingDispatcher:
     """Logs every eights MCP call; can replay scripted responses by tool name."""
+    # E2-22: this suite exercises the in-graph mcp dispatch path with a
+    # scripted pp harness. Opt in explicitly — node_dispatch otherwise
+    # defers mcp packs to the attended host on a non-live dispatcher.
+    allow_offline_mcp_dispatch = True
     def __init__(self, scripted: dict[str, dict] | None = None):
         self.calls: list[dict] = []
         self.scripted = scripted or {}

--- a/tests/test_fable_audit_2.py
+++ b/tests/test_fable_audit_2.py
@@ -55,6 +55,11 @@ class _FakeDispatcher:
     run without errors.
     """
 
+    # E2-22: these tests exercise the in-graph mcp dispatch path with a
+    # scripted pp harness. Opt in explicitly — node_dispatch otherwise
+    # defers mcp packs to the attended host on a non-live dispatcher.
+    allow_offline_mcp_dispatch = True
+
     def __init__(
         self,
         *,
@@ -216,9 +221,15 @@ class TestSupervisorStatusCoercion:
             lambda *_a, **_k: type("V", (), {"aligned": True, "rationale": ""})(),
         )
 
+        # E2-22: node_dispatch defers mcp packs to the attended host on a
+        # non-live dispatcher. This test's concern is the status coercion the
+        # in-graph path applies, so opt back into that path explicitly.
+        class _OfflineDispatcher:
+            allow_offline_mcp_dispatch = True
+
         runner = build_supervisor(
             project_root=HYDRA_ROOT,
-            dispatcher=object(),
+            dispatcher=_OfflineDispatcher(),
             force_pure_python=True,
         )
         assert isinstance(runner, _PurePythonRunner)

--- a/tests/test_judge_supervisor_integration.py
+++ b/tests/test_judge_supervisor_integration.py
@@ -15,6 +15,10 @@ HYDRA_ROOT = Path(__file__).resolve().parents[1]
 
 class _StubDispatcher:
     """Minimal dispatcher protocol stand-in. Returns a fake result envelope."""
+    # E2-22: this suite exercises the in-graph mcp dispatch path with a
+    # scripted pp harness. Opt in explicitly — node_dispatch otherwise
+    # defers mcp packs to the attended host on a non-live dispatcher.
+    allow_offline_mcp_dispatch = True
     def call_mcp(self, server, tool, args, **_kw):
         return {"status": "done", "tool": tool, "result": {"ok": True}}
 

--- a/tests/test_judge_supervisor_phase34.py
+++ b/tests/test_judge_supervisor_phase34.py
@@ -20,6 +20,11 @@ class _StubDispatcher:
     """Returns `done` (not `host_pickup_required`) so the judge plane scores
     the resulting envelopes. Use _HostPickupDispatcher in tests that need
     placeholder behavior."""
+    # E2-22: this suite exercises the in-graph mcp dispatch path with a
+    # scripted pp harness. Opt in explicitly — node_dispatch otherwise
+    # defers mcp packs to the attended host on a non-live dispatcher.
+    allow_offline_mcp_dispatch = True
+
     def call_mcp(self, server, tool, args, **_kw):
         return {"status": "done", "tool": tool, "result": {"ok": True}}
 

--- a/tests/test_ra12_ra10_ra3.py
+++ b/tests/test_ra12_ra10_ra3.py
@@ -36,6 +36,10 @@ HYDRA_ROOT = Path(__file__).resolve().parents[1]
 
 class _StubDispatcher:
     """Minimal dispatcher protocol stand-in. Records MCP calls for assertions."""
+    # E2-22: this suite exercises the in-graph mcp dispatch path with a
+    # scripted pp harness. Opt in explicitly — node_dispatch otherwise
+    # defers mcp packs to the attended host on a non-live dispatcher.
+    allow_offline_mcp_dispatch = True
 
     def __init__(self):
         self.calls: list[tuple[str, str, dict]] = []

--- a/tests/test_reliability_fixes.py
+++ b/tests/test_reliability_fixes.py
@@ -1469,6 +1469,11 @@ class TestJudgePerSquadHaltsOnSurfaced:
         from hydra_core.supervisor import build_supervisor
 
         class _NullDisp:
+            # E2-22: node_dispatch defers mcp packs to the attended host on a
+            # non-live dispatcher, which would end the pass at dispatch. This
+            # test guards the judge->synthesis happy path, so opt back in.
+            allow_offline_mcp_dispatch = True
+
             def call_mcp(self, *_a, **_k):
                 return {"status": "done", "result": {}}
             def emit_claude_prompt(self, *_a, **_k):

--- a/tests/test_ws9_tier_acceptance.py
+++ b/tests/test_ws9_tier_acceptance.py
@@ -20,6 +20,10 @@ import pytest
 @dataclass
 class CaptureDispatcher:
     """Fake dispatcher that records all call_mcp invocations."""
+    # E2-22: this suite exercises the in-graph mcp dispatch path with a
+    # scripted pp harness. Opt in explicitly — node_dispatch otherwise
+    # defers mcp packs to the attended host on a non-live dispatcher.
+    allow_offline_mcp_dispatch: bool = True
     calls: list[dict[str, Any]] = field(default_factory=list)
     mcp_result: dict[str, Any] = field(default_factory=lambda: {
         "status": "done",


### PR DESCRIPTION
## Root cause

An attended `hydra approve` pass re-enters `node_dispatch` with the CLI's inert `_NullDispatcher` (`live_execution` unset). The pre-filter there defers `claude-native` packs, and defers non-mcp packs when the dispatcher IS live, but nothing deferred an `mcp` pack on a non-live dispatcher. Engineering is `entrypoint: mcp`, so it fell through to `_via_mcp`.

The stub response carries a `run_id`, so the whole downstream chain fired on nothing: a placeholder engineering `DECISION_RECORD`, `budget.cost_unavailable`, a NoOp judge verdict with `score_json={"_skeleton": true}`, a Reflexion retry, a second identical skeleton verdict, and a pass running on toward synthesis. All of it before the host had driven a single attended stage.

## Change

`hydra_core/supervisor.py`:

- `node_dispatch` defers mcp packs to the host whenever the dispatcher is not live, the same treatment claude-native packs already get. Callers that genuinely want the in-graph mcp path offline opt in with `allow_offline_mcp_dispatch = True` on their dispatcher; that is what the scripted pp dispatchers in the unit suite now set.
- A pass that parked every task stops at dispatch through a new `await_host` conditional edge to `END`, and holds `phase` at `executing` instead of pre-declaring `judge_per_squad`. `_PurePythonRunner` mirrors the same stop.
- The hold is deliberately narrow. It requires ALL tasks deferred and at least one mcp pack among them, so the live/detached mixed pass keeps judging the leg it actually executed, and all-native workflows keep their existing routing.

The live path (`hydra run --live`, fleet, ingest) is untouched and still covered by `tests/test_dispatch_defer_nonmcp.py`.

## Tests

New file `tests/test_e2_22_attended_defers_engineering.py`, three cases: a three-squad attended state yields three `dispatch.deferred_to_host` events with zero verdicts and phase held at `executing`; an engineering-only attended state defers; the offline opt-in flag still reaches `pp_harness.start_run`.

Seven existing test dispatchers gained the explicit `allow_offline_mcp_dispatch` opt-in, since they exercise the in-graph mcp path with a scripted pp harness.

| Result | Count |
|---|---|
| Passed | 1680 |
| Skipped | 4 |
| Failed | 2 |

Both failures are pre-existing worktree-environment issues unrelated to this change. `test_native_pack_dispatch.py` and `test_claude_native_configuration.py` depend on the `marketing-*` symlink packs, which are absent in a worktree checkout.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
