### PR TITLE
E2-27: judge_model_id validation/normalization; pin errors no longer surface a passing stage

### DIFF
--- a/hydra_core/host_bridge.py
+++ b/hydra_core/host_bridge.py
@@ -205,6 +205,150 @@ def _classify_infra_failure(exc: Exception | None) -> str:
 
 
 # --------------------------------------------------------------------------- #
+# E2-27: judge_model_id validation / normalization                            #
+# --------------------------------------------------------------------------- #
+# pp's ``recordVerdict`` hard-pins the model id a judge may report for the
+# vendors whose critique CLI is itself pinned (codex, agy). A visible judge
+# subagent that reports the model it *thinks* it used (e.g. "gpt-5.1-codex")
+# rather than the id pp's critique tool actually served made record_verdict
+# throw a validation error; the bridge classified that as deterministic-fatal
+# and surfaced an otherwise-PASSING stage with the merge discarded (E2-27).
+#
+# The host now (a) tells the judge which ids are acceptable via the judge
+# host_action, (b) normalizes a mislabeled id to the producer's pinned
+# critique model before calling record_verdict (keeping the reported value in
+# ``score_json["judge_model_id_reported"]``), and (c) treats a pp pin error as
+# host-correctable rather than fatal.
+
+# Suffix the same-vendor Claude judge appends to its producer label (LV-3) so
+# pp's generator-identical producer+model check does not reject the verdict.
+# It is a LABEL, not a vendor: strip it before looking up model pins.
+_SAME_VENDOR_HOST_SUFFIX = "-same-vendor-host"
+
+# Static fallback for pp's pinned critique model ids, used when the
+# ``pp_harness.doctor`` probe is unavailable. Mirrors pp's DEFAULT_MODELS
+# (``codex_critique`` / ``codex_critique_escalated`` / ``agy_critique``).
+# ``claude`` is present with an EMPTY tuple on purpose: pp does not pin Claude
+# critique models, so any id is acceptable and no normalization applies -- but
+# "claude" must still be a KNOWN producer so the same-vendor judge is not
+# rejected as unsupported.
+_STATIC_JUDGE_MODEL_PINS: dict[str, tuple[str, ...]] = {
+    "codex": ("gpt-5.4", "gpt-5.5"),
+    "agy": ("gemini-3.1-pro-preview",),
+    "claude": (),
+}
+
+# Substring identifying pp's judge-model pin rejection on record_verdict.
+# Such a rejection is host-correctable (re-report the model id) rather than a
+# fatal defect in the artifact, so it must NOT surface a passing stage.
+_JUDGE_PIN_ERROR_MARKER = "must record judge_model_id"
+
+# Bound on how many times one judge call_key may be bounced back to the host
+# for a model-id/producer correction before the bridge stops asking and lets
+# the normal (pp-authoritative) path run. Without a bound a host that keeps
+# re-reporting the same unsupported producer would livelock the stage.
+_MAX_JUDGE_MODEL_CORRECTIONS = 2
+
+# Process-level cache of the doctor probe (fail-soft, refreshed on demand).
+_JUDGE_MODEL_PIN_CACHE: dict[str, tuple[str, ...]] | None = None
+
+
+def _base_judge_vendor(producer: Any) -> str:
+    """Strip the LV-3 ``-same-vendor-host`` label suffix off a judge producer."""
+    p = str(producer or "")
+    if p.endswith(_SAME_VENDOR_HOST_SUFFIX):
+        return p[: -len(_SAME_VENDOR_HOST_SUFFIX)]
+    return p
+
+
+def allowed_judge_model_ids(dispatcher: Dispatcher | None,
+                            *, refresh: bool = False) -> dict[str, list[str]]:
+    """Return ``{judge_producer: [acceptable model ids]}``.
+
+    Sourced from ``pp_harness.doctor``'s ``judge_capabilities`` map (the
+    authority on what each vendor's critique tool is pinned to), UNIONED with
+    the static fallback above -- doctor reports only the DEFAULT critique
+    model, while pp additionally accepts codex's escalated id, so neither
+    source alone is complete.
+
+    Fail-soft in every direction: a missing dispatcher, an RBAC denial, a
+    transport error, or a malformed payload all fall back to the static map.
+    An empty list means "this producer is known but pp pins no model for it"
+    (claude), which disables normalization rather than rejecting the verdict.
+    """
+    global _JUDGE_MODEL_PIN_CACHE
+    if _JUDGE_MODEL_PIN_CACHE is not None and not refresh:
+        return {k: list(v) for k, v in _JUDGE_MODEL_PIN_CACHE.items()}
+    pins: dict[str, list[str]] = {
+        k: list(v) for k, v in _STATIC_JUDGE_MODEL_PINS.items()
+    }
+    if dispatcher is not None:
+        try:
+            caps = _pp_inner(_raise_on_error_payload(
+                dispatcher.call_mcp("pp_harness", "doctor", {}, squad_id=_SQ),
+                "doctor",
+            )).get("judge_capabilities")
+            if isinstance(caps, dict):
+                for vendor, summary in caps.items():
+                    if not isinstance(summary, dict):
+                        continue
+                    bucket = pins.setdefault(str(vendor), [])
+                    model = summary.get("critique_model")
+                    if model and str(model) not in bucket:
+                        # Front of the list: doctor's value is the vendor's
+                        # DEFAULT pin, which is what normalization targets.
+                        bucket.insert(0, str(model))
+        except Exception:  # noqa: BLE001 — never block a stage on a probe
+            pass
+    _JUDGE_MODEL_PIN_CACHE = {k: tuple(v) for k, v in pins.items()}
+    return {k: list(v) for k, v in pins.items()}
+
+
+def _reset_judge_model_pin_cache() -> None:
+    """Test hook: drop the cached doctor probe."""
+    global _JUDGE_MODEL_PIN_CACHE
+    _JUDGE_MODEL_PIN_CACHE = None
+
+
+def _is_judge_pin_error(exc: Exception | None) -> bool:
+    """True when a record_verdict failure is pp's judge-model pin rejection.
+
+    That rejection is a LABEL problem the host can correct by re-reporting the
+    model id -- it says nothing about the artifact -- so it must be routed to
+    the host-correctable path instead of ``_classify_infra_failure``'s
+    deterministic-fatal default (which matches on "validation").
+    """
+    if exc is None:
+        return False
+    if _JUDGE_PIN_ERROR_MARKER in str(exc).lower():
+        return True
+    payload = getattr(exc, "payload", None)
+    if isinstance(payload, dict):
+        return _JUDGE_PIN_ERROR_MARKER in str(payload.get("error", "")).lower()
+    return False
+
+
+def _judge_correction_budget_left(cursor: dict[str, Any],
+                                  call_key: str | None) -> bool:
+    """Whether this judge call_key may still be bounced back for a correction."""
+    counts = cursor.get("judge_model_corrections")
+    if not isinstance(counts, dict):
+        return True
+    return int(counts.get(str(call_key), 0)) < _MAX_JUDGE_MODEL_CORRECTIONS
+
+
+def _record_judge_correction(cursor: dict[str, Any],
+                             call_key: str | None) -> int:
+    counts = cursor.get("judge_model_corrections")
+    if not isinstance(counts, dict):
+        counts = {}
+        cursor["judge_model_corrections"] = counts
+    key = str(call_key)
+    counts[key] = int(counts.get(key, 0)) + 1
+    return counts[key]
+
+
+# --------------------------------------------------------------------------- #
 # Worktree isolation (write-safety)                                           #
 # --------------------------------------------------------------------------- #
 # In attended mode the host's visible `engineer` subagent writes code. The
@@ -1770,6 +1914,10 @@ def _apply_generate(dispatcher: Dispatcher, cursor: dict[str, Any],
     # doesn't break retry-safety: the same judge call re-driven on the same
     # attempt still produces the same token.
     judge_call_key = f"judge-{run_id}-{stage_id}-{cursor['attempt_id']}-{gen_idx}"
+    # E2-27: hand the host the model ids pp will accept for each judge
+    # producer, so the judge subagent reports a pinned id instead of guessing
+    # one that record_verdict then rejects.
+    allowed_models = allowed_judge_model_ids(dispatcher)
     cursor["pending_action"] = {
         "call_key": judge_call_key,
         "agent_type": judge_agent,
@@ -1778,11 +1926,16 @@ def _apply_generate(dispatcher: Dispatcher, cursor: dict[str, Any],
         "artifact_text": judge_text,
         "rubric_md": rubric_body,
         "cwd": work_path,
+        "allowed_judge_model_ids": allowed_models,
         "instructions": (
             f"Spawn the visible `{judge_agent}` subagent to judge the diff "
             f"against rubric {gate_rubric}. Then call submit-host-result with "
             "{call_key, result:{outcome:pass|revise|fail, critique_md, "
-            "judge_producer, judge_model_id, score_json, cost_usd}}."),
+            "judge_producer, judge_model_id, score_json, cost_usd}}. "
+            "Report judge_model_id exactly as the critique tool returned it; "
+            "if the tool named no model, use the pinned id for that producer "
+            f"from allowed_judge_model_ids ({allowed_models!r}). Never invent "
+            "a model id."),
     }
     _trace(cursor, "attended.attempt_recorded", {
         "stage_id": stage_id, "attempt_id": cursor["attempt_id"],
@@ -1795,7 +1948,7 @@ def _apply_generate(dispatcher: Dispatcher, cursor: dict[str, Any],
 def _apply_judge(dispatcher: Dispatcher, cursor: dict[str, Any],
                  result: dict[str, Any],
                  *, cursor_file: "str | Path | None" = None,
-                 call_key: str | None = None) -> None:
+                 call_key: str | None = None) -> dict[str, Any] | None:
     """await_judge -> terminal (or back to await_generate for Reflexion x1).
 
     F26+M8: a failed record_verdict/finalize_stage on a pass outcome downgrades
@@ -1808,6 +1961,14 @@ def _apply_judge(dispatcher: Dispatcher, cursor: dict[str, Any],
     Fix-1b: idempotency markers (verdict_recorded_for / smoke_result_for) written
     mid-function so a retried submit after a timeout never double-records in the
     pp ledger or restarts the ~28-min smoke.
+    E2-27: an unsupported judge_producer, or a pp judge-model pin rejection on
+    record_verdict, is HOST-CORRECTABLE -- the cursor stays in ``await_judge``
+    with its pending_action (and call_key) untouched and this function returns
+    a ``{"ok": False, "retryable": True, ...}`` dict for the caller to relay,
+    instead of surfacing a passing stage.
+
+    Returns ``None`` on a normal transition, or the host-correctable error
+    dict described above.
     """
     cm = dispatcher.call_mcp
     producer = cursor["producer"]
@@ -1816,6 +1977,46 @@ def _apply_judge(dispatcher: Dispatcher, cursor: dict[str, Any],
     required_cross = bool(cursor.get("required_cross"))
     gen_idx = cursor.get("generate_index", 0)   # GAP-f: 0=first attempt, 1=retry
     work_path = cursor.get("work_path") or cursor["project_path"]
+
+    # E2-27: validate the judge's self-reported producer BEFORE anything is
+    # accrued or written. An unsupported producer means the host cannot build
+    # a valid record_verdict payload, and pp does not police non-{codex,agy}
+    # vendors -- so a bogus label would otherwise land a bogus vendor in the
+    # ledger. Bounce it back as host-correctable: the cursor is left exactly
+    # as it was (state "await_judge"/"stalled_infra", same pending_action,
+    # same call_key), so a corrected resubmit re-enters here cleanly.
+    allowed_models = allowed_judge_model_ids(dispatcher)
+    _reported_producer = str(result.get("judge_producer")
+                             or ("codex" if required_cross else "claude"))
+    _reported_vendor = _base_judge_vendor(_reported_producer)
+    if _reported_vendor not in allowed_models:
+        if _judge_correction_budget_left(cursor, call_key):
+            n = _record_judge_correction(cursor, call_key)
+            _trace(cursor, "attended.judge_producer_unsupported", {
+                "stage_id": cursor.get("stage_id"), "call_key": call_key,
+                "judge_producer": _reported_producer,
+                "correction_attempt": n,
+                "allowed_judge_model_ids": allowed_models,
+            })
+            if cursor_file is not None:
+                save_cursor(cursor_file, cursor)
+            return {
+                "ok": False,
+                "retryable": True,
+                "error": (
+                    f"judge_producer {_reported_producer!r} is not a supported "
+                    f"judge vendor; resubmit the SAME call_key with a "
+                    f"judge_producer in {sorted(allowed_models)} and a "
+                    f"judge_model_id from allowed_judge_model_ids"),
+                "allowed_judge_model_ids": allowed_models,
+            }
+        # Correction budget exhausted — stop bouncing and let the normal path
+        # run so the stage reaches a decision instead of livelocking.
+        _trace(cursor, "attended.judge_producer_unsupported_accepted", {
+            "stage_id": cursor.get("stage_id"), "call_key": call_key,
+            "judge_producer": _reported_producer,
+            "reason": "correction budget exhausted; proceeding to pp",
+        })
 
     # W2-3: guard cost/token accrual against double-counting when a
     # transport-shaped record_verdict failure holds the cursor open
@@ -1869,6 +2070,30 @@ def _apply_judge(dispatcher: Dispatcher, cursor: dict[str, Any],
     if degraded:
         score_json["_judge_degraded"] = True
 
+    # E2-27: normalize the reported judge_model_id against pp's pins BEFORE
+    # record_verdict. pp pins codex/agy critique models; a judge that names
+    # the model it believes it used ("gpt-5.1-codex") rather than the id the
+    # critique tool served made record_verdict throw, which used to discard a
+    # passing stage. Normalize to the vendor's pinned critique model and keep
+    # the judge's own claim in score_json for audit. Vendors pp does not pin
+    # (claude -> empty list) are passed through untouched.
+    _judge_vendor = _base_judge_vendor(judge_producer)
+    _reported_model = str(result.get("judge_model_id")
+                          or result.get("model") or "").strip()
+    judge_model_id = _reported_model or f"{judge_producer}-default"
+    _vendor_pins = allowed_models.get(_judge_vendor) or []
+    if _vendor_pins and judge_model_id not in _vendor_pins:
+        _pinned = _vendor_pins[0]
+        score_json["judge_model_id_reported"] = _reported_model or None
+        _trace(cursor, "attended.judge_model_id_normalized", {
+            "stage_id": cursor.get("stage_id"), "call_key": call_key,
+            "judge_producer": judge_producer,
+            "reported": _reported_model or None,
+            "normalized_to": _pinned,
+            "allowed_judge_model_ids": _vendor_pins,
+        })
+        judge_model_id = _pinned
+
     # Finding 2: track whether the outcome change is an infra failure (F31 /
     # F26+M8) vs a genuine artifact defect.  Infra failures must surface
     # immediately — Reflexion is reserved for code defects the engineer can fix.
@@ -1907,8 +2132,7 @@ def _apply_judge(dispatcher: Dispatcher, cursor: dict[str, Any],
         _verdict_payload = {
             "attempt_id": attempt_id,
             "judge_producer": judge_producer,
-            "judge_model_id": str(result.get("judge_model_id")
-                                  or result.get("model") or f"{judge_producer}-default"),
+            "judge_model_id": judge_model_id,
             "outcome": outcome if outcome in {"pass", "revise", "fail"} else "revise",
             "critique_md": critique_md[:4000],
             "score_json": score_json,
@@ -1946,6 +2170,45 @@ def _apply_judge(dispatcher: Dispatcher, cursor: dict[str, Any],
             # row and no trace explaining why.
             _record_verdict_ok = False
             _record_verdict_exc = exc
+
+    # E2-27: pp's judge-model pin rejection is a LABEL problem, not an
+    # artifact defect. `_classify_infra_failure` calls it "deterministic"
+    # (its text matches the "validation" marker), which used to surface a
+    # PASSING stage and discard the merge. Route it to the host-correctable
+    # path instead: nothing about the cursor state or pending_action changes,
+    # so a resubmit under the SAME call_key with a corrected judge_model_id
+    # re-enters here and retries record_verdict (no verdict row was written,
+    # so `verdict_recorded_for` is unset and there is nothing to double-write).
+    if not _record_verdict_ok and _is_judge_pin_error(_record_verdict_exc):
+        _pin_reason = str(_record_verdict_exc)
+        if _judge_correction_budget_left(cursor, call_key):
+            n = _record_judge_correction(cursor, call_key)
+            _trace(cursor, "attended.judge_model_id_pin_rejected", {
+                "stage_id": cursor.get("stage_id"), "call_key": call_key,
+                "attempt_id": attempt_id,
+                "judge_producer": judge_producer,
+                "judge_model_id": judge_model_id,
+                "correction_attempt": n,
+                "reason": _pin_reason,
+                "allowed_judge_model_ids": allowed_models,
+            })
+            if cursor_file is not None:
+                save_cursor(cursor_file, cursor)
+            return {
+                "ok": False,
+                "retryable": True,
+                "error": (
+                    "pp rejected the judge model id: " + _pin_reason +
+                    " — resubmit the SAME call_key with a judge_model_id from "
+                    "allowed_judge_model_ids"),
+                "allowed_judge_model_ids": allowed_models,
+            }
+        _trace(cursor, "attended.judge_model_id_pin_unrecoverable", {
+            "stage_id": cursor.get("stage_id"), "call_key": call_key,
+            "reason": _pin_reason,
+            "correction_budget": _MAX_JUDGE_MODEL_CORRECTIONS,
+        })
+
     if outcome == "pass" and not _record_verdict_ok:
         _rv_reason = str(_record_verdict_exc) if _record_verdict_exc is not None else "unknown error"
         _rv_kind = _classify_infra_failure(_record_verdict_exc)
@@ -2802,8 +3065,18 @@ def submit_host_result(
         # submit_host_result carrying the same call_key/result re-enters
         # _apply_judge here and retries record_verdict via the
         # idempotency_token — exactly-once even across the re-drive.
-        _apply_judge(dispatcher, cursor, result,
-                     cursor_file=cursor_file, call_key=call_key)
+        # E2-27: a host-correctable judge label problem (unsupported producer,
+        # or pp's judge-model pin rejection) comes back as a retryable error
+        # dict. The cursor is unchanged and still holds this judge's
+        # pending_action/call_key, so the host corrects the label and
+        # resubmits under the SAME call_key rather than losing the stage.
+        _judge_err = _apply_judge(dispatcher, cursor, result,
+                                  cursor_file=cursor_file, call_key=call_key)
+        if _judge_err is not None:
+            save_cursor(cursor_file, cursor)
+            out = _step_result(cursor, cursor_file)
+            out.update(_judge_err)
+            return out
     elif state == "await_squad_agent":
         # Lightweight non-engineering squad flow — no pp protocol calls needed.
         _apply_squad_result(cursor, result)

--- a/plugins/hydra/agents/judge-cross-vendor.md
+++ b/plugins/hydra/agents/judge-cross-vendor.md
@@ -37,3 +37,12 @@ Return to the parent (hydra.workflow.submit_host_result) with:
 ```
 {call_key: "<as given>", result: {outcome: "pass"|"revise"|"fail", critique_md: "<findings with file paths>", judge_producer: "<your vendor>", judge_model_id: "<model>", score_json: {<per-dimension scores>}, cost_usd: <your cost>}}
 ```
+
+Report `judge_model_id` exactly as returned by the critique tool; if the tool
+response does not state a model, use the pinned id given in
+`allowed_judge_model_ids` for your `judge_producer`. Never invent a model id.
+pp's `record_verdict` hard-pins the critique model for `codex` and `agy`, so a
+guessed id (e.g. `"gpt-5.1-codex"`) is rejected at the ledger. The host
+normalizes an off-pin id and keeps your claim in
+`score_json.judge_model_id_reported`, but it can only do so when the producer
+itself is one it knows — so `judge_producer` must be a real vendor slug.

--- a/plugins/hydra/agents/judge-same-vendor.md
+++ b/plugins/hydra/agents/judge-same-vendor.md
@@ -41,3 +41,11 @@ vendor pinning (`recordVerdict`) rejects a verdict whose `judge_producer` and
 `judge_model_id` both equal the generator's, and the attended generator is
 also Claude — often the same model id. The `-same-vendor-host` label keeps
 the model id honest while satisfying the pinning check (`cross_vendor=0`).
+
+Report `judge_model_id` exactly as returned by the critique tool; if the tool
+response does not state a model, use the pinned id given in
+`allowed_judge_model_ids` for your `judge_producer`. Never invent a model id.
+pp pins no Claude critique model, so report the Claude model you actually ran
+as — but `judge_producer` must stay `"claude-same-vendor-host"`, since the
+host only recognizes real vendor slugs (optionally carrying that suffix) and
+bounces anything else back for correction.

--- a/squads/engineering/squad.yaml
+++ b/squads/engineering/squad.yaml
@@ -131,6 +131,16 @@ tools:
       The RBAC matcher keys on (name, mcp_server), so this entry is REQUIRED for
       pp_codex.critique — the pp_agy entry above does not cover it.
       Not for: code generation — use the codex generate tool instead.
+  - name: doctor
+    mcp_server: pp_harness
+    privilege: read
+    notes: >
+      Read pp's health summary — CLI versions, configured vendors, and the
+      judge_capabilities map naming each vendor's PINNED critique model. The
+      attended bridge reads judge_capabilities so it can hand the judge agent
+      the model ids pp's record_verdict will accept, and normalize a
+      mislabeled judge_model_id instead of losing a passing stage (E2-27).
+      Read-only; called without `smoke` so it never exercises a vendor CLI.
   - name: gate_eligible_judges
     mcp_server: pp_harness
     privilege: read

--- a/tests/test_host_bridge.py
+++ b/tests/test_host_bridge.py
@@ -2421,3 +2421,225 @@ def test_recover_stalled_stage_already_merged_branch_reproduces_live_incident(tm
         "this is the exact data-loss shape from the live incident")
     assert (tmp_path / "important_fix.py").exists()
     assert (tmp_path / "old_feature.py").exists()
+
+
+# --------------------------------------------------------------------------- #
+# E2-27: judge_model_id validation / normalization                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(autouse=True)
+def _clear_judge_pin_cache():
+    """The doctor probe is cached process-wide; keep tests independent."""
+    host_bridge._reset_judge_model_pin_cache()
+    yield
+    host_bridge._reset_judge_model_pin_cache()
+
+
+class _FakeDispatcherWithDoctor(FakeDispatcher):
+    """FakeDispatcher serving pp's doctor judge_capabilities map, and
+    enforcing pp's real record_verdict judge-model pin."""
+
+    def __init__(self, *, enforce_pin: bool = True, **kw):
+        super().__init__(**kw)
+        self._enforce_pin = enforce_pin
+        self.verdicts: list[dict] = []
+
+    def call_mcp(self, server, tool, args, squad_id=None):
+        if tool == "doctor":
+            self.calls.append((server, tool, dict(args), squad_id))
+            return {"status": "done", "result": {"judge_capabilities": {
+                "codex": {"critique_model": "gpt-5.4"},
+                "agy": {"critique_model": "gemini-3.1-pro-preview"},
+                "claude": {"critique_model": None},
+            }}}
+        if tool == "record_verdict":
+            self.calls.append((server, tool, dict(args), squad_id))
+            self.verdicts.append(dict(args))
+            if self._enforce_pin and args.get("judge_producer") == "codex" \
+                    and args.get("judge_model_id") not in {"gpt-5.4", "gpt-5.5"}:
+                return {"status": "failed", "error": (
+                    "judge_producer=codex must record judge_model_id in "
+                    "{gpt-5.4, gpt-5.5} because pp_codex.critique is pinned "
+                    "to those models (default or escalated)")}
+            return {"status": "done", "result": {"verdict_id": "v-1"}}
+        return super().call_mcp(server, tool, args, squad_id)
+
+
+def _drive_to_judge(disp, tmp_path):
+    res = _begin(disp, tmp_path)
+    cfile = res["cursor_path"]
+    res = host_bridge.submit_host_result(
+        disp, cursor_file=cfile, call_key="generate-0",
+        result={"text": "edited foo.py", "cost_usd": 0.10,
+                "model": "claude-opus-4-8"})
+    return cfile, res
+
+
+def test_judge_host_action_carries_allowed_model_ids(tmp_path):
+    disp = _FakeDispatcherWithDoctor(required_cross_vendor=True)
+    _cfile, res = _drive_to_judge(disp, tmp_path)
+    allowed = res["host_action"]["allowed_judge_model_ids"]
+    assert allowed["codex"] == ["gpt-5.4", "gpt-5.5"]
+    assert allowed["agy"] == ["gemini-3.1-pro-preview"]
+    assert allowed["claude"] == []
+    # The instruction the host relays to the judge names the pinned ids.
+    assert "allowed_judge_model_ids" in res["host_action"]["instructions"]
+    assert "Never invent" in res["host_action"]["instructions"]
+    # doctor ran read-only under the engineering RBAC scope.
+    assert ("pp_harness", "doctor", {}, "engineering") in disp.calls
+
+
+def test_mislabeled_codex_model_id_is_normalized_not_fatal(tmp_path):
+    """E2-27: the live incident -- a judge reporting gpt-5.1-codex on a PASS.
+
+    The verdict must be recorded against pp's pinned id, the stage must
+    complete, and the judge's own claim must be preserved for audit.
+    """
+    disp = _FakeDispatcherWithDoctor(required_cross_vendor=True)
+    cfile, _ = _drive_to_judge(disp, tmp_path)
+    res = host_bridge.submit_host_result(
+        disp, cursor_file=cfile,
+        call_key="judge-run-1-stage-1-att-1-0",
+        result={"outcome": "pass", "critique_md": "looks good",
+                "judge_producer": "codex",
+                "judge_model_id": "gpt-5.1-codex", "cost_usd": 0.05})
+
+    assert res["status"] == "complete"
+    assert res["final_status"] == "complete"
+    assert res["stage_outcome"] == "pass"
+    assert len(disp.verdicts) == 1
+    v = disp.verdicts[0]
+    assert v["judge_model_id"] == "gpt-5.4"
+    assert v["judge_producer"] == "codex"
+    assert v["score_json"]["judge_model_id_reported"] == "gpt-5.1-codex"
+
+
+def test_missing_model_id_normalizes_to_pin(tmp_path):
+    """A judge that reports no model id must not send a made-up default."""
+    disp = _FakeDispatcherWithDoctor(required_cross_vendor=True)
+    cfile, _ = _drive_to_judge(disp, tmp_path)
+    res = host_bridge.submit_host_result(
+        disp, cursor_file=cfile,
+        call_key="judge-run-1-stage-1-att-1-0",
+        result={"outcome": "pass", "critique_md": "ok",
+                "judge_producer": "codex", "cost_usd": 0.05})
+    assert res["status"] == "complete"
+    assert disp.verdicts[0]["judge_model_id"] == "gpt-5.4"
+    assert disp.verdicts[0]["score_json"]["judge_model_id_reported"] is None
+
+
+def test_escalated_codex_model_id_passes_through(tmp_path):
+    """gpt-5.5 is a legitimate pp escalation -- do NOT rewrite it to gpt-5.4."""
+    disp = _FakeDispatcherWithDoctor(required_cross_vendor=True)
+    cfile, _ = _drive_to_judge(disp, tmp_path)
+    res = host_bridge.submit_host_result(
+        disp, cursor_file=cfile,
+        call_key="judge-run-1-stage-1-att-1-0",
+        result={"outcome": "pass", "critique_md": "ok",
+                "judge_producer": "codex",
+                "judge_model_id": "gpt-5.5", "cost_usd": 0.05})
+    assert res["status"] == "complete"
+    assert disp.verdicts[0]["judge_model_id"] == "gpt-5.5"
+    assert "judge_model_id_reported" not in disp.verdicts[0]["score_json"]
+
+
+def test_same_vendor_claude_model_id_is_not_normalized(tmp_path):
+    """pp pins no Claude critique model -- the reported id must survive."""
+    disp = _FakeDispatcherWithDoctor(required_cross_vendor=False)
+    cfile, _ = _drive_to_judge(disp, tmp_path)
+    res = host_bridge.submit_host_result(
+        disp, cursor_file=cfile,
+        call_key="judge-run-1-stage-1-att-1-0",
+        result={"outcome": "pass", "critique_md": "ok",
+                "judge_producer": "claude-same-vendor-host",
+                "judge_model_id": "claude-haiku-4", "cost_usd": 0.02})
+    assert res["status"] == "complete"
+    assert disp.verdicts[0]["judge_model_id"] == "claude-haiku-4"
+    assert disp.verdicts[0]["judge_producer"] == "claude-same-vendor-host"
+
+
+def test_record_verdict_pin_error_is_retryable_cursor_stays_await_judge(tmp_path):
+    """E2-27 (3): a pp pin rejection must NOT surface a passing stage.
+
+    Simulated by emptying the pin map so host-side normalization is a no-op
+    and the mislabeled id reaches pp, exactly as it did before this fix.
+    """
+    disp = _FakeDispatcherWithDoctor(required_cross_vendor=True)
+    cfile, judge_res = _drive_to_judge(disp, tmp_path)
+    judge_key = judge_res["host_action"]["call_key"]
+    host_bridge._JUDGE_MODEL_PIN_CACHE = {"codex": (), "agy": (), "claude": ()}
+
+    res = host_bridge.submit_host_result(
+        disp, cursor_file=cfile, call_key=judge_key,
+        result={"outcome": "pass", "critique_md": "looks good",
+                "judge_producer": "codex",
+                "judge_model_id": "gpt-5.1-codex", "cost_usd": 0.05})
+
+    assert res["ok"] is False
+    assert res["retryable"] is True
+    assert "must record judge_model_id" in res["error"]
+    assert "allowed_judge_model_ids" in res
+    # Cursor is NOT terminal and the same judge step is still pending.
+    assert res["status"] == "awaiting_host"
+    assert res["state"] == "await_judge"
+    assert res["host_action"]["call_key"] == judge_key
+    assert disp.count("finalize_stage") == 0
+    assert disp.count("finalize_run") == 0
+    assert host_bridge.load_cursor(cfile)["state"] == "await_judge"
+
+    # A corrected resubmit under the SAME call_key completes the stage.
+    host_bridge._reset_judge_model_pin_cache()
+    res2 = host_bridge.submit_host_result(
+        disp, cursor_file=cfile, call_key=judge_key,
+        result={"outcome": "pass", "critique_md": "looks good",
+                "judge_producer": "codex",
+                "judge_model_id": "gpt-5.4", "cost_usd": 0.05})
+    assert res2["status"] == "complete"
+    assert res2["final_status"] == "complete"
+    # Judge cost was accrued exactly once across both submits.
+    assert res2["cost_usd"] == pytest.approx(0.15)
+
+
+def test_unknown_judge_producer_is_retryable_without_advancing(tmp_path):
+    disp = _FakeDispatcherWithDoctor(required_cross_vendor=True)
+    cfile, judge_res = _drive_to_judge(disp, tmp_path)
+    judge_key = judge_res["host_action"]["call_key"]
+
+    res = host_bridge.submit_host_result(
+        disp, cursor_file=cfile, call_key=judge_key,
+        result={"outcome": "pass", "critique_md": "ok",
+                "judge_producer": "definitely-not-a-vendor",
+                "judge_model_id": "who-knows", "cost_usd": 0.05})
+
+    assert res["ok"] is False and res["retryable"] is True
+    assert "not a supported judge vendor" in res["error"]
+    assert sorted(res["allowed_judge_model_ids"]) == ["agy", "claude", "codex"]
+    assert res["state"] == "await_judge"
+    assert res["host_action"]["call_key"] == judge_key
+    # Nothing was written to the pp ledger and no judge cost was accrued.
+    assert disp.count("record_verdict") == 0
+    assert res["cost_usd"] == pytest.approx(0.10)   # generate only
+
+
+def test_unknown_judge_producer_correction_budget_is_bounded(tmp_path):
+    """A host that keeps re-reporting a bad producer must not livelock."""
+    disp = _FakeDispatcherWithDoctor(required_cross_vendor=True,
+                                     enforce_pin=False)
+    cfile, judge_res = _drive_to_judge(disp, tmp_path)
+    judge_key = judge_res["host_action"]["call_key"]
+    bad = {"outcome": "pass", "critique_md": "ok",
+           "judge_producer": "definitely-not-a-vendor",
+           "judge_model_id": "who-knows", "cost_usd": 0.05}
+
+    for _ in range(host_bridge._MAX_JUDGE_MODEL_CORRECTIONS):
+        res = host_bridge.submit_host_result(
+            disp, cursor_file=cfile, call_key=judge_key, result=dict(bad))
+        assert res["ok"] is False
+
+    # Budget exhausted -- the stage proceeds instead of bouncing forever.
+    res = host_bridge.submit_host_result(
+        disp, cursor_file=cfile, call_key=judge_key, result=dict(bad))
+    assert res.get("retryable") is not True
+    assert res["state"] in host_bridge._TERMINAL
+    assert disp.count("record_verdict") == 1


### PR DESCRIPTION
## What broke

A visible judge subagent returned `outcome=pass, judge_producer=codex, judge_model_id="gpt-5.1-codex"`. pair-programmer's `record_verdict` hard-pins codex critique ids to `{gpt-5.4, gpt-5.5}` and rejected it. `host_bridge._apply_judge` classified that rejection as deterministic-fatal, set the cursor terminal `surfaced` with `stage_outcome="revise"` on a passing verdict, skipped smoke, discarded the merge, and charged $2.12. The green commit was stranded on a preserved branch.

## Fix

1. **`allowed_judge_model_ids(dispatcher)`** reads `pp_harness.doctor` → `judge_capabilities.<vendor>.critique_model`, unions it with a static fallback map (`codex: gpt-5.4/gpt-5.5`, `agy: gemini-3.1-pro-preview`, `claude: []`), and caches per process. Fail-soft in every direction: a missing dispatcher, RBAC denial, transport error, or malformed payload all fall back to the static map.
2. **Judge `host_action` carries `allowed_judge_model_ids`** plus an instruction naming them, so the judge reports a pinned id rather than guessing.
3. **Normalization before `record_verdict`**: an off-pin id is rewritten to the producer's pinned critique model, the judge's own claim is kept in `score_json["judge_model_id_reported"]`, and `attended.judge_model_id_normalized` is traced. A legitimate escalation (`gpt-5.5`) passes through untouched, and vendors pp does not pin (claude) are never rewritten.
4. **Host-correctable errors**: an unsupported `judge_producer`, and a pp pin rejection on `record_verdict`, now return `{ok: false, retryable: true, error, allowed_judge_model_ids}` with the cursor left in `await_judge` and the same `pending_action`/`call_key`. A corrected resubmit under the same `call_key` completes the stage; the existing `judge_cost_applied_for` guard keeps the cost accrued exactly once. Bounded at 2 corrections per `call_key` so a host that keeps re-reporting a bad producer cannot livelock the stage.
5. **Both judge prompts** (`judge-cross-vendor.md`, `judge-same-vendor.md`) now say to report `judge_model_id` exactly as the critique tool returned it, fall back to the pinned id in `allowed_judge_model_ids`, and never invent one.
6. **`squads/engineering/squad.yaml`** grants `pp_harness.doctor` read privilege (called without `smoke`, so it never exercises a vendor CLI).

The `-same-vendor-host` producer suffix (LV-3) is stripped before pin lookup, so the same-vendor Claude judge is not mistaken for an unknown vendor.

## Tests

Eight new tests in `tests/test_host_bridge.py`: host_action carries the allowed ids; the live mislabeled-codex case normalizes and completes with `judge_model_id_reported` recorded; a missing id normalizes to the pin; `gpt-5.5` passes through; a Claude same-vendor id is untouched; a pp pin error is retryable with the cursor still `await_judge` and a corrected resubmit completing; an unknown producer is retryable with nothing written to the ledger; the correction budget is bounded.

| Suite | Result |
|---|---|
| `tests/test_host_bridge.py` | 61 passed |
| `-k "host_bridge or judge or attended"` | 187 passed, 1 failed |
| full `pytest -q` | 1685 passed, 4 skipped, 2 failed |

The 2 failures (`test_claude_native_configuration.py::test_operator_skills_use_canonical_namespace_without_project_duplicates`, `test_native_pack_dispatch.py::test_active_source_packs_are_host_attended_native_plugins`) are pre-existing worktree-environment failures: the `marketing-*` squad packs are symlinks into the MarketBliss checkout and do not resolve inside a linked worktree. Confirmed by stashing the change and re-running both files — identical failures.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
