### PR TITLE
E2-33: pyproject license metadata matches LICENSE (MIT)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,8 @@ version = "0.1.0"
 description = "Hydra — central supervisor / state engine for the Enterprise Agent Mesh"
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "Proprietary" }
+license = "MIT"
+license-files = ["LICENSE"]
 dependencies = [
   "pydantic>=2.6",
   "PyYAML>=6.0",

--- a/tests/test_license_metadata.py
+++ b/tests/test_license_metadata.py
@@ -1,0 +1,70 @@
+"""Packaging metadata must agree with the LICENSE file (finding E2-33).
+
+`pyproject.toml` once declared ``license = { text = "Proprietary" }`` while the
+repository shipped an MIT `LICENSE`. These tests keep the two in lockstep.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+LICENSE = REPO_ROOT / "LICENSE"
+
+# SPDX identifier -> the first line the matching LICENSE file must carry.
+_SPDX_TO_HEADING = {
+    "MIT": "MIT License",
+    "Apache-2.0": "Apache License",
+    "BSD-3-Clause": "BSD 3-Clause License",
+}
+
+
+@pytest.fixture(scope="module")
+def project_table() -> dict:
+    with PYPROJECT.open("rb") as handle:
+        return tomllib.load(handle)["project"]
+
+
+def test_license_is_an_spdx_expression(project_table: dict) -> None:
+    """PEP 639: ``license`` is a string SPDX expression, not a legacy table."""
+    license_value = project_table["license"]
+    assert isinstance(license_value, str), (
+        "expected a PEP 639 SPDX string, got a legacy table: " f"{license_value!r}"
+    )
+    assert license_value in _SPDX_TO_HEADING, f"unrecognized SPDX identifier {license_value!r}"
+
+
+def test_license_files_points_at_the_license(project_table: dict) -> None:
+    assert project_table["license-files"] == ["LICENSE"]
+    assert LICENSE.is_file(), "pyproject references LICENSE but the file is missing"
+
+
+def test_pyproject_license_matches_license_file(project_table: dict) -> None:
+    """The declared SPDX identifier must match the LICENSE file's first line."""
+    first_line = LICENSE.read_text(encoding="utf-8").splitlines()[0].strip()
+    expected = _SPDX_TO_HEADING[project_table["license"]]
+    assert first_line == expected, (
+        f"pyproject declares {project_table['license']!r} but LICENSE begins {first_line!r}"
+    )
+
+
+def test_no_license_classifier(project_table: dict) -> None:
+    """PEP 639 forbids ``License ::`` classifiers beside an SPDX expression."""
+    classifiers = project_table.get("classifiers", [])
+    offenders = [c for c in classifiers if c.startswith("License ::")]
+    assert not offenders, f"remove deprecated license classifiers: {offenders}"
+
+
+def test_build_backend_supports_pep_639() -> None:
+    """setuptools gained PEP 639 support in 77.0.0."""
+    with PYPROJECT.open("rb") as handle:
+        requires = tomllib.load(handle)["build-system"]["requires"]
+    setuptools_pin = next(r for r in requires if r.startswith("setuptools"))
+    floor = setuptools_pin.split(">=", 1)[1].strip()
+    assert tuple(int(part) for part in floor.split(".")) >= (77,), (
+        f"PEP 639 needs setuptools>=77, pyproject pins {setuptools_pin!r}"
+    )


### PR DESCRIPTION
Fixes finding E2-33: `pyproject.toml` declared `license = { text = "Proprietary" }` while the repository ships an MIT `LICENSE` ("MIT License / Copyright (c) 2026 Rob Hasselbach").

## Change
- `license = "MIT"` and `license-files = ["LICENSE"]` (PEP 639 form).
- Build requirement raised from `setuptools>=68` to `setuptools>=77`, the first release that supports PEP 639. The installed setuptools is 82.0.1.
- No `License :: OSI Approved :: MIT License` classifier was added. PEP 639 forbids `License ::` classifiers alongside an SPDX expression, and the project declares no classifiers list at all.

## Test
`tests/test_license_metadata.py` (5 tests) asserts the SPDX identifier is a string expression, `license-files` points at an existing `LICENSE`, the identifier matches the first line of that file, no license classifier creeps back, and the setuptools floor supports PEP 639.

Verified that generated wheel metadata now carries `License-Expression: MIT` and `License-File: LICENSE`.

## Operator decision
This aligns packaging with the existing MIT `LICENSE`, which is what the Senate record recommended. If proprietary licensing was in fact intended, the correct fix is the opposite one: replace the `LICENSE` file and revert this change. `LICENSE` was not modified here.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki