### PR TITLE
E2-31: spawnable lead agent + real cwd for claude-skill packs

### DIFF
--- a/hydra_core/cli.py
+++ b/hydra_core/cli.py
@@ -1532,6 +1532,115 @@ def _next_nonengineering_attended_task(state: HydraState, packs: dict):
     return None, None
 
 
+def _pack_lead_agent_spec(pack):
+    """The pack's lead AgentSpec: first gatekeeper, else first agent, else None."""
+    agents = list(getattr(pack, "agents", []) or [])
+    for a in agents:
+        if getattr(a, "authority", "") == "gatekeeper":
+            return a
+    return agents[0] if agents else None
+
+
+def _skill_pack_checkout(pack) -> Path | None:
+    """Real on-disk checkout of a claude-skill pack, or None.
+
+    ``squads/<slug>/`` holds only Hydra's squad.yaml overlay -- the agents and
+    the pack's slash command live in the sibling repo named by ``source_pack``
+    (a repo URL, or a filesystem path for a locally vendored pack). The repo id
+    is the URL's last segment, resolved through the allow-listed registry.
+    """
+    src = str(getattr(pack, "source_pack", None) or "").strip()
+    if not src:
+        return None
+    if "://" not in src:
+        p = Path(src).expanduser()
+        if p.is_dir():
+            return p.resolve()
+    repo_id = src.rstrip("/").replace("\\", "/").rsplit("/", 1)[-1]
+    if repo_id.endswith(".git"):
+        repo_id = repo_id[:-4]
+    if not repo_id:
+        return None
+    try:
+        from .repo_registry import resolve_repo_path
+        return resolve_repo_path(repo_id.lower())
+    except Exception:  # noqa: BLE001 -- unregistered/absent checkout is not fatal
+        return None
+
+
+def _agent_frontmatter_name(agent_path: Path) -> str | None:
+    """Top-level ``name:`` from a Claude Code agent file's YAML frontmatter."""
+    try:
+        text = agent_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    block = text[3:end] if end != -1 else text[3:]
+    for line in block.splitlines():
+        if line.startswith("name:"):  # top-level key only (no indent)
+            return line[len("name:"):].strip().strip("\"'") or None
+    return None
+
+
+def _resolve_claude_skill_host_action(pack) -> dict:
+    """Host-action fields for a claude-skill pack's attended lead agent.
+
+    E2-31: the bare squad.yaml slug (e.g. ``support-supervisor``) is NOT a
+    spawnable agent type -- pack agents live in the sibling checkout under their
+    own frontmatter names. Resolve a spawnable identity instead:
+
+    * pack installed as a Claude Code plugin (``.claude-plugin/plugin.json``)
+      -> ``"<plugin-name>:<agent frontmatter name>"``;
+    * otherwise -> ``"general-purpose"`` plus ``skill`` (the pack's slash
+      command) and ``tool_scope`` (its MCP shim prefix) so the host drives the
+      pack through its declared command and MCP tools.
+
+    ``lead_agent_file`` is always included when resolvable, for transparency.
+    """
+    action: dict = {"agent_type": "general-purpose"}
+    checkout = _skill_pack_checkout(pack)
+    spec = _pack_lead_agent_spec(pack)
+
+    agent_path: Path | None = None
+    if checkout is not None and spec is not None and getattr(spec, "agent_file", None):
+        from .squad_loader import resolve_agent_file_path
+        try:
+            agent_path = resolve_agent_file_path(checkout, spec.agent_file)
+        except FileNotFoundError:
+            candidate = checkout / spec.agent_file
+            agent_path = candidate if candidate.is_file() else None
+    if agent_path is not None:
+        action["lead_agent_file"] = str(agent_path)
+
+    plugin_name: str | None = None
+    if checkout is not None:
+        manifest = checkout / ".claude-plugin" / "plugin.json"
+        if manifest.is_file():
+            try:
+                plugin_name = (json.loads(manifest.read_text(encoding="utf-8"))
+                               .get("name") or None)
+            except (OSError, ValueError):
+                plugin_name = None
+
+    if plugin_name and agent_path is not None:
+        agent_name = _agent_frontmatter_name(agent_path) or agent_path.stem
+        action["agent_type"] = f"{plugin_name}:{agent_name}"
+        return action
+
+    # Not plugin-loadable: drive the pack's slash command through its MCP shim.
+    from .squad_node import _SKILL_PACK_SHIMS
+    shim = _SKILL_PACK_SHIMS.get(pack.slug) or {}
+    invoke = getattr(pack, "invoke", None) or {}
+    command = invoke.get("command_hint") or shim.get("default_cmd")
+    if command:
+        action["skill"] = command
+    if shim.get("prefix"):
+        action["tool_scope"] = shim["prefix"]
+    return action
+
+
 def _resolve_pack_lead_agent(pack) -> str:
     """Resolve the supervisor / lead agent slug for a squad pack.
 
@@ -1541,13 +1650,10 @@ def _resolve_pack_lead_agent(pack) -> str:
     if getattr(pack, "entrypoint", None) == "claude-native":
         from .native_packs import native_pack
         return native_pack(pack.slug).qualified_lead_agent
-    agents = list(getattr(pack, "agents", []) or [])
-    for a in agents:
-        if getattr(a, "authority", "") == "gatekeeper":
-            return a.slug
-    if agents:
-        return agents[0].slug
-    return "general-purpose"
+    if getattr(pack, "entrypoint", None) == "claude-skill":
+        return _resolve_claude_skill_host_action(pack)["agent_type"]
+    spec = _pack_lead_agent_spec(pack)
+    return spec.slug if spec is not None else "general-purpose"
 
 
 def _resolve_pack_cwd(pack, project: Path) -> str:
@@ -1560,6 +1666,12 @@ def _resolve_pack_cwd(pack, project: Path) -> str:
     if getattr(pack, "entrypoint", None) == "claude-native":
         from .native_packs import native_pack_root
         return str(native_pack_root(pack.slug))
+    if getattr(pack, "entrypoint", None) == "claude-skill":
+        # E2-31: squads/<slug>/ is only Hydra's overlay -- the agents, skills and
+        # slash command live in the pack's own checkout.
+        checkout = _skill_pack_checkout(pack)
+        if checkout is not None:
+            return str(checkout)
     from .squad_loader import SQUAD_DIR_NAMES, USER_SQUAD_DIR
     for dir_name in SQUAD_DIR_NAMES:
         candidate = project / dir_name / pack.slug
@@ -1807,9 +1919,15 @@ def _cmd_attended_step(args) -> int:
             task_id = str(ne_task.task_id)
             request_text = ne_task.description or state.root_goal
             pack_cwd = _resolve_pack_cwd(ne_pack, project)
-            lead_agent = _resolve_pack_lead_agent(ne_pack)
+            action_extras = None
+            if ne_pack.entrypoint == "claude-skill":
+                action_extras = _resolve_claude_skill_host_action(ne_pack)
+                lead_agent = action_extras.pop("agent_type")
+            else:
+                lead_agent = _resolve_pack_lead_agent(ne_pack)
 
             res = host_bridge.begin_squad_stage(
+                action_extras=action_extras,
                 workflow_id=wf,
                 task_id=task_id,
                 squad_slug=ne_pack.slug,

--- a/hydra_core/host_bridge.py
+++ b/hydra_core/host_bridge.py
@@ -2310,6 +2310,7 @@ def begin_squad_stage(
     pack_cwd: str,
     request_text: str,
     project_root: str | Path,
+    action_extras: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Create a lightweight cursor for an attended non-engineering squad task
     (claude-skill or agent-impersonation entrypoint).
@@ -2348,6 +2349,12 @@ def begin_squad_stage(
             "instructions": "Run the pack agent and submit the artifact.",
         },
     }
+    # E2-31: claude-skill packs that are not plugin-loadable carry the pack's
+    # slash command + MCP tool scope so the host can drive them via
+    # general-purpose; `lead_agent_file` is informational.
+    if action_extras:
+        cursor["pending_action"].update(
+            {k: v for k, v in action_extras.items() if k != "agent_type"})
     cfile = cursor_path(project_root, workflow_id, task_id)
     save_cursor(cfile, cursor)
     _trace(cursor, "attended.squad_stage_started", {

--- a/tests/test_claude_skill_lead_agent.py
+++ b/tests/test_claude_skill_lead_agent.py
@@ -1,0 +1,128 @@
+"""E2-31 — claude-skill packs resolve to a spawnable lead agent + real cwd.
+
+`_resolve_pack_lead_agent` used to hand the host the bare squad.yaml slug
+(e.g. `support-supervisor`) with `cwd=<Hydra>/squads/customer-support`. Neither
+is real: the agent lives in the pack's own checkout under its frontmatter name,
+and the squads/ dir holds only Hydra's overlay. These tests pin the fixed
+contract.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hydra_core.cli import (
+    _resolve_claude_skill_host_action,
+    _resolve_pack_cwd,
+    _resolve_pack_lead_agent,
+)
+from hydra_core.squad_loader import AgentSpec, SquadPack, discover_squads
+
+HYDRA_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _make_pack_checkout(root: Path, *, with_plugin_json: bool) -> Path:
+    """A fake pack checkout with a hestia agent, optionally plugin-installed."""
+    checkout = root / "Xenia"
+    (checkout / ".claude" / "agents").mkdir(parents=True)
+    (checkout / ".claude" / "agents" / "hestia.md").write_text(
+        "---\nname: hestia\ndescription: \"Support supervisor.\"\nmodel: opus\n"
+        "tools:\n  - Read\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    if with_plugin_json:
+        (checkout / ".claude-plugin").mkdir()
+        (checkout / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"name": "xenia", "version": "1.0.0"}), encoding="utf-8")
+    return checkout
+
+
+def _fake_pack(checkout: Path) -> SquadPack:
+    return SquadPack(
+        slug="customer-support",
+        name="Customer Support",
+        description="fake pack",
+        source_pack=str(checkout),
+        entrypoint="claude-skill",
+        agents=(
+            AgentSpec(slug="support-supervisor", role="lead",
+                      authority="gatekeeper",
+                      agent_file=".claude/agents/hestia.md"),
+            AgentSpec(slug="intake-router", role="router", authority="execute",
+                      agent_file=".claude/agents/iris.md"),
+        ),
+        invoke={"command_hint": "/support-ticket"},
+    )
+
+
+class TestPluginInstalledPack:
+    def test_lead_agent_is_plugin_qualified_frontmatter_name(self, tmp_path):
+        pack = _fake_pack(_make_pack_checkout(tmp_path, with_plugin_json=True))
+        assert _resolve_pack_lead_agent(pack) == "xenia:hestia"
+
+    def test_host_action_carries_lead_agent_file_and_no_skill_shim(self, tmp_path):
+        checkout = _make_pack_checkout(tmp_path, with_plugin_json=True)
+        action = _resolve_claude_skill_host_action(_fake_pack(checkout))
+        assert action["agent_type"] == "xenia:hestia"
+        assert Path(action["lead_agent_file"]) == checkout / ".claude" / "agents" / "hestia.md"
+        assert Path(action["lead_agent_file"]).is_file()
+        # A plugin-loadable agent is spawned directly; no command indirection.
+        assert "skill" not in action
+
+
+class TestNonPluginPack:
+    def test_falls_back_to_general_purpose_with_skill_and_tool_scope(self, tmp_path):
+        checkout = _make_pack_checkout(tmp_path, with_plugin_json=False)
+        action = _resolve_claude_skill_host_action(_fake_pack(checkout))
+        assert action["agent_type"] == "general-purpose"
+        assert action["skill"] == "/support-ticket"
+        # customer-support's MCP shim prefix (hydra_core.squad_node._SKILL_PACK_SHIMS)
+        assert action["tool_scope"] == "xenia"
+        assert Path(action["lead_agent_file"]).is_file()
+
+    def test_lead_agent_never_returns_the_bare_squad_slug(self, tmp_path):
+        pack = _fake_pack(_make_pack_checkout(tmp_path, with_plugin_json=False))
+        assert _resolve_pack_lead_agent(pack) != "support-supervisor"
+
+
+class TestPackCwd:
+    def test_cwd_is_the_pack_checkout_not_the_squads_overlay(self, tmp_path):
+        checkout = _make_pack_checkout(tmp_path, with_plugin_json=True)
+        cwd = Path(_resolve_pack_cwd(_fake_pack(checkout), HYDRA_ROOT))
+        assert cwd == checkout.resolve()
+        assert "squads" not in cwd.parts
+
+    def test_unresolvable_checkout_falls_back_to_squads_dir(self, tmp_path):
+        """A pack whose source_pack cannot be resolved still gets a usable cwd."""
+        pack = SquadPack(
+            slug="customer-support", name="cs", description="",
+            source_pack="https://github.com/lebobo88/NoSuchRepoHere",
+            entrypoint="claude-skill",
+        )
+        cwd = Path(_resolve_pack_cwd(pack, HYDRA_ROOT))
+        assert cwd.is_dir()
+
+
+class TestRealCustomerSupportPack:
+    """Against the real registry: the resolved agent file must actually exist."""
+
+    def test_customer_support_resolves_to_an_existing_agent_file(self):
+        pack = discover_squads(HYDRA_ROOT).get("customer-support")
+        if pack is None or pack.entrypoint != "claude-skill":
+            pytest.skip("customer-support claude-skill pack not registered")
+        action = _resolve_claude_skill_host_action(pack)
+        if "lead_agent_file" not in action:
+            pytest.skip("Xenia checkout not present in this environment")
+        agent_file = Path(action["lead_agent_file"])
+        assert agent_file.is_file(), f"lead agent file missing: {agent_file}"
+        cwd = Path(_resolve_pack_cwd(pack, HYDRA_ROOT))
+        assert agent_file.is_relative_to(cwd)
+        if action["agent_type"] != "general-purpose":
+            # Plugin-qualified: the suffix must be the file's frontmatter name.
+            from hydra_core.cli import _agent_frontmatter_name
+            expected = _agent_frontmatter_name(agent_file) or agent_file.stem
+            assert action["agent_type"].endswith(f":{expected}")
+        else:
+            assert action["skill"] and action["tool_scope"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -951,7 +951,13 @@ def test_attended_squad_path_completes_charges_once_no_redispatch(
     assert payload_step["state"] == "await_squad_agent", (
         f"expected await_squad_agent, got {payload_step['state']!r}"
     )
-    assert payload_step["host_action"]["agent_type"] == "brand-director"
+    # E2-31: a claude-skill pack never hands the host the bare squad.yaml slug.
+    # This fake pack has no resolvable checkout, so it degrades to the
+    # general-purpose host agent driving the pack's slash command + MCP shim.
+    _skill_action = payload_step["host_action"]
+    assert _skill_action["agent_type"] == "general-purpose"
+    assert _skill_action["skill"] == "/rlm-creative:creative-campaign"
+    assert _skill_action["tool_scope"] == "rlm"
 
     cfile = payload_step["cursor_path"]
     call_key = payload_step["host_action"]["call_key"]


### PR DESCRIPTION
## Problem

For `claude-skill` packs, `_resolve_pack_lead_agent` returned the bare `squad.yaml` slug (observed: `support-supervisor`) and `_resolve_pack_cwd` returned `<Hydra>/squads/customer-support`. Neither is real: the agent lives in the Xenia checkout under its frontmatter name (`hestia`), and the squads dir holds only Hydra's overlay `squad.yaml`. A host following the drive contract could not spawn the customer-support leg.

## Fix

`claude-skill` packs now resolve against the pack's real checkout, found from `source_pack` (repo-URL last segment through the allow-listed repo registry, or a local filesystem path):

- checkout has `.claude-plugin/plugin.json` with a `name` → `agent_type = "<plugin>:<agent frontmatter name>"` (file stem as fallback).
- otherwise → `agent_type = "general-purpose"`, plus `skill` (the pack's `invoke.command_hint`, else the shim `default_cmd`) and `tool_scope` (the pack's MCP shim prefix from `_SKILL_PACK_SHIMS`) so the host drives the pack through its declared command and tools.
- `lead_agent_file` is always included in the host action when resolvable.
- `_resolve_pack_cwd` returns the checkout, falling back to the old squads-dir behavior when the checkout cannot be resolved.
- `host_bridge.begin_squad_stage` takes an optional `action_extras` dict merged into `pending_action`.

Live check against the real registry: customer-support resolves to `agent_type=general-purpose`, `skill=/support-ticket`, `tool_scope=xenia`, `lead_agent_file=C:\AiAppDeployments\Xenia\.claude\agents\hestia.md`, `cwd=C:\AiAppDeployments\Xenia` (Xenia ships no `plugin.json`).

## Tests

New `tests/test_claude_skill_lead_agent.py` (7 tests): plugin-installed fake pack → `xenia:hestia`; no plugin.json → `general-purpose` + skill/tool_scope; cwd is the checkout and not under `squads/`; unresolvable checkout still yields a usable cwd; and a real-registry test asserting the resolved `lead_agent_file` exists, lives under the resolved cwd, and matches the frontmatter name (skips when the checkout is absent).

One existing assertion in `tests/test_cli.py` pinned the old bare-slug behavior and was updated to the fixed contract; that test's subject (charge-once, no re-dispatch) is unchanged.

| Suite | Result |
|---|---|
| `-k "skill or lead_agent or attended or shim"` | 61 passed, 1 skipped |
| full `pytest -q` | 1684 passed, 4 skipped, 2 failed |

The 2 failures (`test_operator_skills_use_canonical_namespace_without_project_duplicates`, `test_active_source_packs_are_host_attended_native_plugins`) are the known worktree-env failures from absent `marketing-*` symlinks; both reproduce on the base commit with this branch's changes stashed.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki