### PR TITLE
E2-26: hermetic pytest suite (no real daemons, no live spool writes)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ and approval-gated execution, with server-side WS-AUTH capability enforcement on
 - Type-annotate everything in `hydra_core/`.
 - Keep `hydra_core/` runtime-agnostic — dispatchers are injected, no provider SDK imports.
 - Tests under `tests/` use `pytest`. Avoid network or LLM calls in unit tests.
+- **hermetic suite** (E2-26): `tests/conftest.py` redirects every Hydra state path (`HYDRA_HOME`, `HYDRA_EPISODIC_DB`, `HYDRA_CHECKPOINT_DB`, `HYDRA_BACKENDS`, `HYDRA_EIGHTS_SPOOL`, `HYDRA_EIGHTS_DEAD_LETTER`) into `.tmp-pytest/hydra-home/` and sets `HYDRA_TEST_NO_DAEMONS=1`, which makes `MCPStdioDispatcher.call_mcp` refuse to fork a stdio daemon. Never write a test that needs the operator's real `~/.hydra`; a test that genuinely needs a daemon carries `@pytest.mark.live_daemon` and runs only under `pytest -m live_daemon`.
 - **no-premature-done**: do not declare a task done until `pytest` (the full relevant suite, not just the new test) passes and the build is clean. A frozen contract in a sibling module can break silently if only the new test is checked.
 
 ## Security

--- a/hydra_core/dispatcher.py
+++ b/hydra_core/dispatcher.py
@@ -80,7 +80,29 @@ def _load_user_scope_mcp() -> dict[str, dict[str, Any]]:
     return {name: _strip_comments(spec) for name, spec in servers.items()}
 
 
-BACKEND_REGISTRY = Path.home() / ".hydra" / "backends.json"
+# E2-26: `HYDRA_BACKENDS` redirects the Hydra-owned backend registry. It is
+# read at import time because `hydra_core.cli` imports the constant directly
+# (and WRITES to it in `hydra export-backends` / `hydra setup`), so a single
+# resolved path must be shared by every consumer. The pytest conftest points
+# it at a temp file holding no stdio backends, so a test run can neither read
+# the operator's real server specs nor overwrite them.
+BACKEND_REGISTRY = Path(
+    os.environ.get("HYDRA_BACKENDS")
+    or (Path.home() / ".hydra" / "backends.json")
+)
+
+# E2-26: hard kill-switch for daemon spawning. When `HYDRA_TEST_NO_DAEMONS=1`
+# the live dispatcher refuses to open a stdio session, so no `node
+# TheEights/daemon/dist/index.js` (or pp / AgentSmith) child is ever forked
+# from a pytest process. Set by the test conftest; unset for tests carrying
+# the `live_daemon` marker.
+NO_DAEMONS_ENV = "HYDRA_TEST_NO_DAEMONS"
+NO_DAEMONS_ERROR = "daemons disabled under tests (HYDRA_TEST_NO_DAEMONS=1)"
+
+
+def daemons_disabled() -> bool:
+    """True when stdio daemon spawning is disabled for this process."""
+    return os.environ.get(NO_DAEMONS_ENV) == "1"
 
 
 def _load_backend_registry() -> dict[str, dict[str, Any]]:
@@ -339,6 +361,13 @@ class MCPStdioDispatcher:
         if venom_block is not None:
             self._record_tool_usage(server, tool, squad_id, "rejected")
             return venom_block
+        # E2-26: refuse to fork a stdio daemon under the test guard. Placed
+        # AFTER the RBAC and venom gates so their (non-spawning) verdicts keep
+        # their exact semantics, and immediately BEFORE the only two code
+        # paths that open an `stdio_client`.
+        if daemons_disabled():
+            self._record_tool_usage(server, tool, squad_id, "failed")
+            return {"status": "failed", "error": NO_DAEMONS_ERROR}
         import time as _time
         _t0 = _time.monotonic()
         if server in self._POOLED_SERVERS:

--- a/hydra_core/eights/pending_spool.py
+++ b/hydra_core/eights/pending_spool.py
@@ -41,6 +41,28 @@ from typing import Any, Callable, Iterable
 DEFAULT_SPOOL_ROOT = Path.home() / ".hydra" / "eights-pending"
 DEFAULT_DEAD_LETTER_ROOT = Path.home() / ".hydra" / "eights-pending-dead"
 
+# E2-26: the spool root is operator state. `HYDRA_EIGHTS_SPOOL` was already
+# honoured by the CLI (`hydra doctor`, `hydra eights-replay`) but NOT by the
+# `PendingSpool()` default used by `EightsAttestor`, so a test run wrote real
+# failure payloads into the operator's live `~/.hydra/eights-pending`. Both
+# roots now resolve through the environment at *construction* time (not
+# import time) so an in-test `monkeypatch.setenv` takes effect too.
+#
+#   HYDRA_EIGHTS_SPOOL       -> spool root       (pre-existing name)
+#   HYDRA_EIGHTS_DEAD_LETTER -> dead-letter root (added by E2-26)
+
+
+def resolve_spool_root() -> Path:
+    """Spool root: ``HYDRA_EIGHTS_SPOOL`` env override, else the default."""
+    return Path(os.environ.get("HYDRA_EIGHTS_SPOOL") or DEFAULT_SPOOL_ROOT)
+
+
+def resolve_dead_letter_root() -> Path:
+    """Dead-letter root: ``HYDRA_EIGHTS_DEAD_LETTER`` override, else default."""
+    return Path(
+        os.environ.get("HYDRA_EIGHTS_DEAD_LETTER") or DEFAULT_DEAD_LETTER_ROOT
+    )
+
 
 @dataclass
 class SpooledCall:
@@ -101,11 +123,11 @@ class PendingSpool:
         *,
         dead_letter_root: Path | str | None = None,
     ) -> None:
-        self.root = Path(root) if root is not None else DEFAULT_SPOOL_ROOT
+        self.root = Path(root) if root is not None else resolve_spool_root()
         self.dead_letter_root = (
             Path(dead_letter_root)
             if dead_letter_root is not None
-            else DEFAULT_DEAD_LETTER_ROOT
+            else resolve_dead_letter_root()
         )
         # Lazy mkdir — the spool only materializes when something is spooled
         # so a clean install with healthy eights never creates the directory.

--- a/hydra_core/memory.py
+++ b/hydra_core/memory.py
@@ -11,6 +11,7 @@ authority for resolving handles back to content.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -24,8 +25,16 @@ from .eights.classifier import classify
 from .schemas import MemoryRef
 
 
-DEFAULT_DIR = Path.home() / ".hydra"
-EPISODIC_DB = DEFAULT_DIR / "episodic.db"
+# E2-26: both are resolved at import time (the public helpers below bind
+# ``EPISODIC_DB`` as a default argument), so the env overrides must be set
+# before ``hydra_core.memory`` is first imported. The pytest conftest sets
+# them at conftest-import time, which is strictly earlier than any test
+# module import.
+#
+#   HYDRA_HOME        -> the Hydra state directory (default ``~/.hydra``)
+#   HYDRA_EPISODIC_DB -> the episodic SQLite file (added by E2-26)
+DEFAULT_DIR = Path(os.environ.get("HYDRA_HOME") or (Path.home() / ".hydra"))
+EPISODIC_DB = Path(os.environ.get("HYDRA_EPISODIC_DB") or (DEFAULT_DIR / "episodic.db"))
 
 
 # --------- episodic ---------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ include = ["hydra_core*"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 norecursedirs = [".*", "build", "dist", "node_modules", "maf-template", "web", ".tmp*", ".harness", ".hydra"]
+markers = [
+  "live_daemon: test needs a real MCP stdio daemon (TheEights / pair-programmer / AgentSmith). Skipped by default; run with `pytest -m live_daemon`, which also lifts the HYDRA_TEST_NO_DAEMONS spawn guard (E2-26).",
+]
 
 [tool.ruff]
 line-length = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,21 +1,145 @@
-"""Shared pytest fixtures for the Hydra test suite."""
+"""Shared pytest fixtures for the Hydra test suite.
+
+E2-26 — hermetic Hydra home
+===========================
+The suite used to run against the operator's real ``~/.hydra``: it spawned the
+live TheEights / pair-programmer / AgentSmith stdio daemons out of
+``~/.hydra/backends.json`` and wrote test failure payloads into the production
+``~/.hydra/eights-pending`` spool (463 entries in a 40-minute window). This
+module redirects every piece of Hydra state that a test can touch to a
+throwaway directory under ``<repo>/.tmp-pytest/`` and disables daemon spawning
+outright.
+
+The redirect happens at **module import time**, not inside a fixture, because
+several ``hydra_core`` modules bind their paths as import-time constants or as
+default arguments (``memory.EPISODIC_DB``, ``dispatcher.BACKEND_REGISTRY``).
+pytest imports this conftest before it imports any test module, which is the
+last moment at which setting the environment still wins. The session-scoped
+``hermetic_hydra_home`` fixture below re-asserts the same environment so the
+invariant is visible (and enforced) at run time as well.
+
+Environment overrides used, and where each is resolved:
+
+===========================  ================================================
+``HYDRA_HOME``               ``hydra_core.memory.DEFAULT_DIR`` (added E2-26)
+``HYDRA_EPISODIC_DB``        ``hydra_core.memory.EPISODIC_DB`` (added E2-26)
+``HYDRA_CHECKPOINT_DB``      ``hydra_core.supervisor`` (pre-existing, C2)
+``HYDRA_BACKENDS``           ``hydra_core.dispatcher.BACKEND_REGISTRY``
+                             (added E2-26)
+``HYDRA_EIGHTS_SPOOL``       ``pending_spool.resolve_spool_root`` (name
+                             pre-existing in the CLI; now also honoured by
+                             ``PendingSpool()`` itself — E2-26)
+``HYDRA_EIGHTS_DEAD_LETTER`` ``pending_spool.resolve_dead_letter_root``
+                             (added E2-26)
+``HYDRA_TEST_NO_DAEMONS``    ``hydra_core.dispatcher`` spawn guard (added
+                             E2-26); unset for ``live_daemon`` tests
+===========================  ================================================
+
+A test that genuinely needs a live daemon carries ``@pytest.mark.live_daemon``.
+Those tests are skipped by default and run with ``pytest -m live_daemon``,
+which also lifts the spawn guard for the marked test only.
+"""
 from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
 
 import pytest
 
 
-@pytest.fixture(autouse=True)
-def _isolate_claude_engineer_env(monkeypatch):
-    """Hermetic default: never let the operator's ``HYDRA_CLAUDE_ENGINEER`` /
-    ``HYDRA_DISABLE_CLAUDE_ENGINEER`` shell env leak into a test run.
+# --------------------------------------------------------------------------
+# Hermetic Hydra home — installed at conftest import, before hydra_core loads.
+# --------------------------------------------------------------------------
 
-    ``HYDRA_CLAUDE_ENGINEER=1`` is an explicit force-on for headless Claude
-    generation; if it leaked in, a scripted-dispatcher test exercising the drive
-    loop would try to spawn a real ``claude`` subprocess. Unset both flags by
-    default; tests that need them opt in via ``monkeypatch.setenv`` in-test.
+#: Repo-local because the sandboxed Windows runs cannot write the system temp
+#: dir (same constraint the root conftest's ``tmp_path`` override documents).
+HERMETIC_HOME = (
+    Path(__file__).resolve().parent.parent / ".tmp-pytest" / "hydra-home"
+)
+
+LIVE_DAEMON_MARKER = "live_daemon"
+NO_DAEMONS_ENV = "HYDRA_TEST_NO_DAEMONS"
+
+
+def _install_hermetic_env() -> dict[str, str]:
+    """Point every Hydra state path at :data:`HERMETIC_HOME`. Idempotent."""
+    HERMETIC_HOME.mkdir(parents=True, exist_ok=True)
+
+    # A backend registry with NO stdio backends: even if the spawn guard were
+    # lifted, there is no server spec to fork. `_load_backend_registry` expects
+    # a flat ``{name: spec}`` object.
+    backends = HERMETIC_HOME / "backends.json"
+    if not backends.exists():
+        backends.write_text(json.dumps({}, indent=2), encoding="utf-8")
+
+    env = {
+        "HYDRA_HOME": str(HERMETIC_HOME),
+        "HYDRA_EPISODIC_DB": str(HERMETIC_HOME / "episodic.db"),
+        "HYDRA_CHECKPOINT_DB": str(HERMETIC_HOME / "checkpoints.db"),
+        "HYDRA_BACKENDS": str(backends),
+        "HYDRA_EIGHTS_SPOOL": str(HERMETIC_HOME / "eights-pending"),
+        "HYDRA_EIGHTS_DEAD_LETTER": str(HERMETIC_HOME / "eights-pending-dead"),
+        NO_DAEMONS_ENV: "1",
+    }
+    os.environ.update(env)
+    return env
+
+
+HERMETIC_ENV = _install_hermetic_env()
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip ``live_daemon`` tests unless they were explicitly selected.
+
+    ``-m live_daemon`` (or any ``-m`` expression naming the marker) opts in;
+    a default run never spawns a daemon.
     """
+    selected = config.getoption("markexpr", default="") or ""
+    if LIVE_DAEMON_MARKER in selected:
+        return
+    skip = pytest.mark.skip(
+        reason="needs a live MCP daemon; run with -m live_daemon"
+    )
+    for item in items:
+        if item.get_closest_marker(LIVE_DAEMON_MARKER) is not None:
+            item.add_marker(skip)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def hermetic_hydra_home() -> dict[str, str]:
+    """Session guarantee that the hermetic environment is in place.
+
+    The environment was already installed at import time (see the module
+    docstring); this fixture re-asserts it so a stray ``os.environ.clear()``
+    in one test cannot silently un-hermetic the rest of the session, and so
+    the redirect is discoverable as a fixture rather than only as a side
+    effect of importing this file.
+    """
+    return _install_hermetic_env()
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_hydra_env(request, monkeypatch):
+    """Per-test env hygiene.
+
+    * Re-affirms the hermetic Hydra paths (a previous test may have pointed
+      one of them elsewhere with its own ``monkeypatch``).
+    * Lifts the daemon spawn guard for ``@pytest.mark.live_daemon`` tests.
+    * Keeps the operator's ``HYDRA_CLAUDE_ENGINEER`` /
+      ``HYDRA_DISABLE_CLAUDE_ENGINEER`` / ``HYDRA_BEST_OF_N`` shell env out of
+      the run. ``HYDRA_CLAUDE_ENGINEER=1`` is an explicit force-on for
+      headless Claude generation; if it leaked in, a scripted-dispatcher test
+      exercising the drive loop would try to spawn a real ``claude``
+      subprocess. Opt-in best-of-N must not leak in either and silently turn
+      single-candidate drive tests into best-of runs (which would spawn real
+      worktrees/subprocesses). Tests that need them opt in via
+      ``monkeypatch.setenv`` in-test.
+    """
+    for key, value in HERMETIC_ENV.items():
+        monkeypatch.setenv(key, value)
+    if request.node.get_closest_marker(LIVE_DAEMON_MARKER) is not None:
+        monkeypatch.delenv(NO_DAEMONS_ENV, raising=False)
     monkeypatch.delenv("HYDRA_CLAUDE_ENGINEER", raising=False)
     monkeypatch.delenv("HYDRA_DISABLE_CLAUDE_ENGINEER", raising=False)
-    # Opt-in best-of-N must not leak in and silently turn single-candidate drive
-    # tests into best-of runs (which would spawn real worktrees/subprocesses).
     monkeypatch.delenv("HYDRA_BEST_OF_N", raising=False)

--- a/tests/test_dispatcher_timeout.py
+++ b/tests/test_dispatcher_timeout.py
@@ -108,6 +108,12 @@ class _FakeStdioCtx:
 
 
 def _install_fake_mcp(monkeypatch, session: _FakeSession):
+    # E2-26: these tests drive `call_mcp` against an in-memory fake MCP SDK —
+    # `_FakeStdioCtx` forks nothing — so the `HYDRA_TEST_NO_DAEMONS` spawn
+    # guard installed by tests/conftest.py must be lifted here, or every
+    # transport assertion below would short-circuit to the disabled payload.
+    # They are NOT `live_daemon` tests: no real daemon is ever contacted.
+    monkeypatch.delenv("HYDRA_TEST_NO_DAEMONS", raising=False)
     mcp = types.ModuleType("mcp")
     mcp.ClientSession = lambda read, write: session
     mcp.StdioServerParameters = lambda **kw: types.SimpleNamespace(**kw)
@@ -197,6 +203,9 @@ def test_wedged_teardown_hits_overall_deadline_backstop(monkeypatch, disp):
     client = types.ModuleType("mcp.client")
     stdio = types.ModuleType("mcp.client.stdio")
     stdio.stdio_client = lambda params: _HangingTeardownStdioCtx()
+    # E2-26: in-memory fake MCP SDK — nothing is forked. Lift the
+    # conftest spawn guard so `call_mcp` reaches the transport path.
+    monkeypatch.delenv("HYDRA_TEST_NO_DAEMONS", raising=False)
     monkeypatch.setitem(sys.modules, "mcp", mcp)
     monkeypatch.setitem(sys.modules, "mcp.client", client)
     monkeypatch.setitem(sys.modules, "mcp.client.stdio", stdio)
@@ -235,6 +244,9 @@ def test_pp_harness_calls_reuse_one_pooled_session(monkeypatch, disp):
     client = types.ModuleType("mcp.client")
     stdio = types.ModuleType("mcp.client.stdio")
     stdio.stdio_client = lambda params: _CountingStdioCtx()
+    # E2-26: in-memory fake MCP SDK — nothing is forked. Lift the
+    # conftest spawn guard so `call_mcp` reaches the transport path.
+    monkeypatch.delenv("HYDRA_TEST_NO_DAEMONS", raising=False)
     monkeypatch.setitem(sys.modules, "mcp", mcp)
     monkeypatch.setitem(sys.modules, "mcp.client", client)
     monkeypatch.setitem(sys.modules, "mcp.client.stdio", stdio)
@@ -273,6 +285,9 @@ def test_pooled_session_drop_hits_teardown_deadline(monkeypatch, disp):
     client = types.ModuleType("mcp.client")
     stdio = types.ModuleType("mcp.client.stdio")
     stdio.stdio_client = lambda params: _HangingTeardownStdioCtx()
+    # E2-26: in-memory fake MCP SDK — nothing is forked. Lift the
+    # conftest spawn guard so `call_mcp` reaches the transport path.
+    monkeypatch.delenv("HYDRA_TEST_NO_DAEMONS", raising=False)
     monkeypatch.setitem(sys.modules, "mcp", mcp)
     monkeypatch.setitem(sys.modules, "mcp.client", client)
     monkeypatch.setitem(sys.modules, "mcp.client.stdio", stdio)
@@ -308,6 +323,9 @@ def test_eights_calls_reuse_one_pooled_session(monkeypatch, disp):
     client = types.ModuleType("mcp.client")
     stdio = types.ModuleType("mcp.client.stdio")
     stdio.stdio_client = lambda params: _CountingStdioCtx()
+    # E2-26: in-memory fake MCP SDK — nothing is forked. Lift the
+    # conftest spawn guard so `call_mcp` reaches the transport path.
+    monkeypatch.delenv("HYDRA_TEST_NO_DAEMONS", raising=False)
     monkeypatch.setitem(sys.modules, "mcp", mcp)
     monkeypatch.setitem(sys.modules, "mcp.client", client)
     monkeypatch.setitem(sys.modules, "mcp.client.stdio", stdio)
@@ -342,6 +360,9 @@ def test_eights_concurrent_connect_is_single_flight(monkeypatch, disp):
     client = types.ModuleType("mcp.client")
     stdio = types.ModuleType("mcp.client.stdio")
     stdio.stdio_client = lambda params: _CountingStdioCtx()
+    # E2-26: in-memory fake MCP SDK — nothing is forked. Lift the
+    # conftest spawn guard so `call_mcp` reaches the transport path.
+    monkeypatch.delenv("HYDRA_TEST_NO_DAEMONS", raising=False)
     monkeypatch.setitem(sys.modules, "mcp", mcp)
     monkeypatch.setitem(sys.modules, "mcp.client", client)
     monkeypatch.setitem(sys.modules, "mcp.client.stdio", stdio)

--- a/tests/test_hermetic_suite.py
+++ b/tests/test_hermetic_suite.py
@@ -1,0 +1,117 @@
+"""E2-26 guard: the suite must not touch the operator's live Hydra state.
+
+These tests fail loudly if the hermetic redirect installed by
+``tests/conftest.py`` regresses — either because an env override stopped being
+honoured by its resolving module, or because the daemon spawn guard stopped
+short-circuiting ``MCPStdioDispatcher.call_mcp``.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from hydra_core import dispatcher as dispatcher_mod
+from hydra_core import memory as memory_mod
+from hydra_core.dispatcher import MCPStdioDispatcher
+from hydra_core.eights import pending_spool
+
+
+# Recomputed here rather than imported from ``conftest``: with a rootdir
+# conftest.py present, the module name ``conftest`` is ambiguous.
+HERMETIC_HOME = (
+    Path(__file__).resolve().parent.parent / ".tmp-pytest" / "hydra-home"
+)
+REAL_HYDRA_HOME = Path.home() / ".hydra"
+
+
+def _under_hermetic_home(path: Path) -> bool:
+    try:
+        Path(path).resolve().relative_to(HERMETIC_HOME.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+@pytest.mark.parametrize(
+    "env_var",
+    [
+        "HYDRA_HOME",
+        "HYDRA_EPISODIC_DB",
+        "HYDRA_CHECKPOINT_DB",
+        "HYDRA_BACKENDS",
+        "HYDRA_EIGHTS_SPOOL",
+        "HYDRA_EIGHTS_DEAD_LETTER",
+    ],
+)
+def test_state_env_redirected_under_tmp(env_var: str) -> None:
+    value = os.environ.get(env_var)
+    assert value, f"{env_var} must be set by the hermetic conftest"
+    assert _under_hermetic_home(Path(value)), (
+        f"{env_var}={value!r} escapes the hermetic home {HERMETIC_HOME}"
+    )
+
+
+def test_module_constants_follow_the_env() -> None:
+    """The resolving modules actually honour the overrides."""
+    assert _under_hermetic_home(memory_mod.EPISODIC_DB)
+    assert _under_hermetic_home(memory_mod.DEFAULT_DIR)
+    assert _under_hermetic_home(dispatcher_mod.BACKEND_REGISTRY)
+    assert _under_hermetic_home(pending_spool.resolve_spool_root())
+    assert _under_hermetic_home(pending_spool.resolve_dead_letter_root())
+
+
+def test_default_pending_spool_writes_into_tmp(tmp_path: Path) -> None:
+    """``PendingSpool()`` with no explicit root must not target real ~/.hydra."""
+    spool = pending_spool.PendingSpool()
+    assert _under_hermetic_home(spool.root)
+    assert _under_hermetic_home(spool.dead_letter_root)
+    assert spool.root != pending_spool.DEFAULT_SPOOL_ROOT
+    assert not _is_under(spool.root, REAL_HYDRA_HOME)
+
+
+def _is_under(path: Path, parent: Path) -> bool:
+    try:
+        Path(path).resolve().relative_to(parent.resolve())
+    except (ValueError, OSError):
+        return False
+    return True
+
+
+def test_backend_registry_has_no_stdio_backends() -> None:
+    """Even with the guard lifted there is no server spec to fork."""
+    assert dispatcher_mod._load_backend_registry() == {}
+
+
+def test_call_mcp_refuses_to_spawn_a_daemon(tmp_path: Path) -> None:
+    """The headline E2-26 assertion: no `node …/daemon/dist/index.js` child."""
+    assert dispatcher_mod.daemons_disabled() is True
+    disp = MCPStdioDispatcher(project_root=tmp_path)
+    result = disp.call_mcp("eights", "eights.squad.list", {})
+    assert result == {
+        "status": "failed",
+        "error": dispatcher_mod.NO_DAEMONS_ERROR,
+    }
+
+
+def test_guard_can_be_lifted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`live_daemon` tests get the real code path back (spawn not attempted
+    here — only the branch condition is asserted)."""
+    monkeypatch.delenv("HYDRA_TEST_NO_DAEMONS", raising=False)
+    assert dispatcher_mod.daemons_disabled() is False
+
+
+@pytest.mark.live_daemon
+def test_live_daemon_marker_opt_in(tmp_path: Path) -> None:
+    """Exercises the opt-in path itself.
+
+    Skipped by every default run; under ``pytest -m live_daemon`` the conftest
+    lifts ``HYDRA_TEST_NO_DAEMONS`` for marked tests, so this asserts the
+    guard is genuinely off. It still contacts no daemon — the hermetic backend
+    registry is empty, so the call fails as an unregistered server.
+    """
+    assert dispatcher_mod.daemons_disabled() is False
+    disp = MCPStdioDispatcher(project_root=tmp_path)
+    result = disp.call_mcp("eights", "eights.squad.list", {})
+    assert result.get("error") != dispatcher_mod.NO_DAEMONS_ERROR


### PR DESCRIPTION
## What

The pytest suite ran against the operator's live `~/.hydra`. `MCPStdioDispatcher` forked the real TheEights / pair-programmer / AgentSmith stdio daemons out of `~/.hydra/backends.json`, and test failure payloads were written into the production `~/.hydra/eights-pending` spool.

`tests/conftest.py` now installs a hermetic Hydra home under `<repo>/.tmp-pytest/hydra-home` at conftest-import time. It has to be import time, not fixture time, because several state paths are import-time constants or bound default arguments in `hydra_core`.

| Env var | Resolved in | Status |
|---|---|---|
| `HYDRA_HOME` | `hydra_core/memory.py` | env read added |
| `HYDRA_EPISODIC_DB` | `hydra_core/memory.py` | env read added |
| `HYDRA_CHECKPOINT_DB` | `hydra_core/supervisor.py` | pre-existing |
| `HYDRA_BACKENDS` | `hydra_core/dispatcher.py` | env read added |
| `HYDRA_EIGHTS_SPOOL` | `hydra_core/eights/pending_spool.py` | name pre-existing in the CLI, now honoured by `PendingSpool()` itself |
| `HYDRA_EIGHTS_DEAD_LETTER` | `hydra_core/eights/pending_spool.py` | env read added |
| `HYDRA_TEST_NO_DAEMONS` | `hydra_core/dispatcher.py` | new spawn guard |

The temp `backends.json` declares no stdio backends, and `MCPStdioDispatcher.call_mcp` short-circuits to `{"status": "failed", "error": "daemons disabled under tests (HYDRA_TEST_NO_DAEMONS=1)"}` while the guard is set. The guard sits after the RBAC and venom gates, so their verdicts keep their exact semantics, and immediately before the only two paths that open an `stdio_client`.

## live_daemon marker

Registered in `pyproject.toml`. Marked tests are skipped unless `-m` names the marker; the per-test fixture lifts the spawn guard for them.

No pre-existing test actually required a live daemon. The eight `tests/test_dispatcher_timeout.py` tests that failed under the guard drive an in-memory fake MCP SDK that forks nothing, so they lift the guard inline instead of being marked `live_daemon` (marking them would have deselected real transport coverage). One new test, `test_live_daemon_marker_opt_in`, carries the marker so the opt-in path itself is exercised.

## Test counts

| Run | Passed | Skipped | Failed |
|---|---|---|---|
| Baseline (before) | 1682 | 1 | 2 known |
| This branch | 1688 | 5 | 2 known |

The two failures are `test_active_source_packs_are_host_attended_native_plugins` and `test_operator_skills_use_canonical_namespace_without_project_duplicates`. Both were confirmed to fail identically on the stashed tree, and both are worktree-environment artifacts: the `marketing-*` squad symlinks and the operator skills namespace are absent in a worktree checkout.

The extra skips are the new `live_daemon` test plus environment-conditional skips (Xenia `sign.py`, `rlm_creative` user-scope registration, Senate sibling checkout) that this worktree does not satisfy.

## Spool evidence

A before/after count of the operator's real spool is not decisive right now: sibling agent worktrees are concurrently running the unfixed suite and writing into `~/.hydra/eights-pending` continuously, with writes landing in every one-minute bucket including windows where this agent ran no pytest at all.

The causal proof used instead: the full suite was run with `HOME` and `USERPROFILE` pointed at an empty scratch directory. Afterwards that directory contained **no `.hydra` directory at all**, so no spool file, `episodic.db`, `checkpoints.db` or `backends.json` write escapes the redirect by any `Path.home()` path. Same result: 1688 passed, 5 skipped, 2 known failures.

Test-local state instead landed under `.tmp-pytest/hydra-home/`: 110 spool entries, 6 dead-letter entries, an `episodic.db` and a `checkpoints.db` — the traffic that previously went to production.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
