### PR TITLE
gateway: expand ${VAR} references in backend env/args

### DIFF
--- a/docs/MCP_SETUP.md
+++ b/docs/MCP_SETUP.md
@@ -128,6 +128,54 @@ In gateway mode, `~/.claude.json` contains only `hydra_gateway`. The actual back
 
 `~/.hydra/backends.json` is machine-local and **never committed** (it holds resolved absolute paths). The committed source of truth is `scripts/backends.template.json`, which uses `{{AIAPP_BASE}}` / `{{HYDRA_ROOT}}` placeholders. Regenerate it by re-running `scripts/setup.{ps1,sh}` — never hand-edit absolute paths into the registry. See [`PORTABILITY.md`](./PORTABILITY.md).
 
+### Referencing secrets from the environment
+
+A backend spec's `env` map is handed verbatim to the child process, so writing a
+secret directly into `~/.hydra/backends.json` leaves long-lived key material in
+a plaintext config that every dispatcher reads and `hydra gateway-backup`
+copies. Reference the launching environment instead:
+
+```jsonc
+"xenia_tickets": {
+  "env": {
+    "PYTHONPATH": "/path/to/Hydra",
+    "HYDRA_OPERATOR_KEY": "${HYDRA_OPERATOR_KEY}",
+    "PP_TIER": "${PP_TIER:-standard}"
+  }
+}
+```
+
+Both the gateway backend pool and Hydra's internal dispatcher resolve these
+references through `hydra_core/backends_env.py` just before building the stdio
+process parameters, so the two paths cannot drift. The same expansion applies to
+`args`, `command`, and `cwd`.
+
+| Form | Resolves to |
+|---|---|
+| `${VAR}` | the value of `VAR`, or `""` plus a WARNING naming the variable when unset |
+| `${VAR:-default}` | the value of `VAR` when set and non-empty, otherwise `default` (never warns) |
+| `$${VAR}` | the literal text `${VAR}` |
+
+Expansion is fail-soft: a missing variable never crashes a dispatch. The backend
+fails on its own terms instead, which for `HYDRA_OPERATOR_KEY` means WS-AUTH
+degrades and Xenia's `send_response` / `execute_approved` reject.
+
+Set the variable before starting Claude Code so it is inherited by the gateway:
+
+```bash
+export HYDRA_OPERATOR_KEY="…"      # macOS / Linux / Git Bash
+```
+
+```powershell
+$env:HYDRA_OPERATOR_KEY = "…"      # PowerShell (or set it as a user env var)
+```
+
+`hydra gateway-export-backends` rewrites any inline 64-hex env value it finds to
+the matching `${VAR}` reference on the way out, and `hydra doctor` warns when
+`backends.json` still holds one. Both are shape checks — neither ever prints the
+value. `hydra doctor` reports `source=env` when the operator key arrives through
+a `${VAR}` reference, and `source=backends.json` only when it is still inline.
+
 ## Available Backends
 
 The 16 backends below mirror `scripts/backends.template.json` — the **single

--- a/hydra_core/backends_env.py
+++ b/hydra_core/backends_env.py
@@ -1,0 +1,159 @@
+"""``${VAR}`` expansion for MCP backend specs (E2-5).
+
+Backend specs (``~/.hydra/backends.json``, ``~/.claude.json`` mcpServers,
+``.mcp.json``) carry an ``env`` map that is handed verbatim to the stdio child
+process.  Historically the only way to give a backend a secret was to write the
+secret *inline* into that JSON file, which puts long-lived key material into a
+plaintext config that is read by every dispatcher, copied by
+``hydra gateway-backup``, and easy to leak.
+
+This module lets a spec reference the parent process environment instead::
+
+    "env": {"HYDRA_OPERATOR_KEY": "${HYDRA_OPERATOR_KEY}"}
+    "env": {"PP_TIER": "${PP_TIER:-standard}"}
+
+Both the gateway backend pool (``mcp_servers/hydra_gateway/server.py``) and the
+direct dispatcher (``hydra_core.dispatcher.MCPStdioDispatcher``) run every spec
+through :func:`expand_spec_env` before building ``StdioServerParameters``, so
+the two paths cannot drift.
+
+Contract:
+
+* ``${VAR}``            -> ``os.environ["VAR"]``; if unset, log a WARNING that
+  names the variable (never a value) and substitute the empty string.
+* ``${VAR:-default}``   -> ``os.environ["VAR"]`` when set and non-empty,
+  otherwise ``default``.  A default never warns.
+* ``$${...}``           -> a literal ``${...}`` (escape hatch for a value that
+  really does contain the sigil).
+* Anything else is passed through untouched.
+
+Expansion is **fail-soft by design**: a missing variable must never crash a
+dispatch.  A backend that needs the secret fails closed on its own terms (an
+empty operator key degrades WS-AUTH), which is a clearer failure than an
+exception thrown from transport setup.
+
+No function in this module ever logs, returns, or embeds a *resolved* value in
+a message.  :func:`looks_like_inline_secret` is a shape check only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "expand_env_refs",
+    "expand_spec_env",
+    "has_env_ref",
+    "looks_like_inline_secret",
+]
+
+# ${VAR} or ${VAR:-default}.  A doubled sigil ($${...}) is handled by the
+# replacement callback below, which sees the leading "$" via the escape group.
+_REF_RE = re.compile(
+    r"(?P<escape>\$?)\$\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>[^}]*))?\}"
+)
+
+# A 64-character hex string — the shape of the operator key minted by
+# ``hydra_core.auth.capability``.  Used ONLY to warn that a config file looks
+# like it holds inline key material; the value itself is never printed.
+_INLINE_SECRET_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def has_env_ref(value: Any) -> bool:
+    """True when ``value`` is a string containing at least one ``${VAR}`` ref."""
+    if not isinstance(value, str):
+        return False
+    return any(m.group("escape") != "$" for m in _REF_RE.finditer(value))
+
+
+def looks_like_inline_secret(value: Any) -> bool:
+    """True when ``value`` has the shape of an inline 64-hex secret.
+
+    Pattern check only.  Callers use this to emit a "move this to the
+    environment" warning; the value must never be printed or logged.
+    """
+    return isinstance(value, str) and bool(_INLINE_SECRET_RE.match(value.strip()))
+
+
+def expand_env_refs(
+    value: Any,
+    *,
+    environ: Mapping[str, str] | None = None,
+    context: str = "",
+) -> Any:
+    """Expand ``${VAR}`` / ``${VAR:-default}`` references inside ``value``.
+
+    Non-string values are returned unchanged.  A reference to a variable that
+    is unset (or set to the empty string) and carries no default expands to
+    ``""`` and logs one WARNING naming the variable.
+    """
+    if not isinstance(value, str):
+        return value
+
+    env = os.environ if environ is None else environ
+    where = f" ({context})" if context else ""
+
+    def _sub(match: "re.Match[str]") -> str:
+        if match.group("escape") == "$":
+            # "$${VAR}" -> literal "${VAR}"
+            return match.group(0)[1:]
+        name = match.group("name")
+        default = match.group("default")
+        resolved = env.get(name) or ""
+        if resolved:
+            return resolved
+        if default is not None:
+            return default
+        logger.warning(
+            "backend env reference ${%s} is unset%s; substituting empty string. "
+            "Set %s in the environment that launches Hydra.",
+            name, where, name,
+        )
+        return ""
+
+    return _REF_RE.sub(_sub, value)
+
+
+def expand_spec_env(
+    spec: Mapping[str, Any],
+    *,
+    environ: Mapping[str, str] | None = None,
+    server: str | None = None,
+) -> dict[str, Any]:
+    """Return a copy of ``spec`` with ``env`` values and ``args`` expanded.
+
+    The input mapping is never mutated — callers pass the registry's own dict
+    and must not have it rewritten under them.  ``env`` keys are left alone;
+    only values are expanded.  ``command`` and ``cwd`` are expanded too so a
+    spec can reference a root path from the environment.
+    """
+    out: dict[str, Any] = dict(spec)
+    ctx = f"server={server}" if server else ""
+
+    env = spec.get("env")
+    if isinstance(env, Mapping):
+        out["env"] = {
+            str(k): expand_env_refs(
+                v, environ=environ, context=f"{ctx} key={k}" if ctx else f"key={k}"
+            )
+            for k, v in env.items()
+        }
+
+    args = spec.get("args")
+    if isinstance(args, (list, tuple)):
+        out["args"] = [
+            expand_env_refs(a, environ=environ, context=ctx) for a in args
+        ]
+
+    for field in ("command", "cwd"):
+        if isinstance(spec.get(field), str):
+            out[field] = expand_env_refs(
+                spec[field], environ=environ, context=ctx
+            )
+
+    return out

--- a/hydra_core/cli.py
+++ b/hydra_core/cli.py
@@ -312,26 +312,58 @@ def _cmd_doctor(args) -> int:
     # print the key or its length. OK when HYDRA_OPERATOR_KEY is non-empty in
     # os.environ OR present under any backend spec's env block in
     # ~/.hydra/backends.json (read-only parse, fail-soft on IO/parse errors).
+    #
+    # E2-5: a backends.json value may now be a "${HYDRA_OPERATOR_KEY}"
+    # reference rather than the key itself. A reference that resolves reports
+    # source=env (the key lives in the environment, not the file); one that does
+    # not resolve leaves the probe unprovisioned. Only a literal value still
+    # reports source=backends.json, and any inline 64-hex-shaped value in the
+    # file draws a WARN naming its backend and key — never its content.
     try:
+        from .backends_env import (
+            expand_env_refs, has_env_ref, looks_like_inline_secret,
+        )
+
         _wsauth_src: str | None = None
+        # E2-5: names of backends whose env holds an inline-secret-shaped value.
+        # Shape check only — no value is ever read into the message.
+        _inline_hits: list[str] = []
         if os.environ.get("HYDRA_OPERATOR_KEY"):
             _wsauth_src = "env"
-        else:
-            try:
-                _bj_path = Path.home() / ".hydra" / "backends.json"
-                if _bj_path.exists():
-                    _bj = json.loads(_bj_path.read_text(encoding="utf-8"))
-                    if isinstance(_bj, dict):
-                        for _bj_spec in _bj.values():
-                            if (
-                                isinstance(_bj_spec, dict)
-                                and isinstance(_bj_spec.get("env"), dict)
-                                and _bj_spec["env"].get("HYDRA_OPERATOR_KEY")
-                            ):
-                                _wsauth_src = "backends.json"
-                                break
-            except Exception:  # noqa: BLE001 — fail-soft on parse / IO errors
-                pass
+        try:
+            _bj_path = Path.home() / ".hydra" / "backends.json"
+            if _bj_path.exists():
+                _bj = json.loads(_bj_path.read_text(encoding="utf-8"))
+                if isinstance(_bj, dict):
+                    for _bj_name, _bj_spec in _bj.items():
+                        if not (
+                            isinstance(_bj_spec, dict)
+                            and isinstance(_bj_spec.get("env"), dict)
+                        ):
+                            continue
+                        for _ek, _ev in _bj_spec["env"].items():
+                            if looks_like_inline_secret(_ev):
+                                _inline_hits.append(f"{_bj_name}.env.{_ek}")
+                        _raw = _bj_spec["env"].get("HYDRA_OPERATOR_KEY")
+                        if _wsauth_src or not _raw:
+                            continue
+                        if has_env_ref(_raw):
+                            # E2-5: a ${VAR} reference — the key really lives in
+                            # the environment, so report source=env when it
+                            # resolves, and stay unprovisioned when it does not.
+                            if expand_env_refs(_raw):
+                                _wsauth_src = "env"
+                        else:
+                            _wsauth_src = "backends.json"
+        except Exception:  # noqa: BLE001 — fail-soft on parse / IO errors
+            pass
+        if _inline_hits:
+            print(
+                "WARN: backends.json holds inline secret-shaped value(s) at "
+                f"{', '.join(sorted(_inline_hits))} — replace with a "
+                "${VAR} reference and export the variable instead "
+                "(see docs/MCP_SETUP.md)"
+            )
         if _wsauth_src:
             print(f"OK:   WS-AUTH operator key configured (source={_wsauth_src})")
         else:
@@ -3002,6 +3034,29 @@ def _cmd_gateway_backup(args) -> int:
     return 0
 
 
+def _redact_inline_secrets(spec: dict) -> list[str]:
+    """Rewrite inline-secret-shaped env values in ``spec`` to ``${KEY}`` refs.
+
+    Mutates ``spec["env"]`` in place and returns the sorted list of env keys
+    that were rewritten. Detection is a shape check only
+    (``backends_env.looks_like_inline_secret``); the value is never printed,
+    logged, or returned.
+    """
+    from .backends_env import looks_like_inline_secret
+
+    if not isinstance(spec, dict):
+        return []
+    env = spec.get("env")
+    if not isinstance(env, dict):
+        return []
+    rewritten: list[str] = []
+    for key, value in list(env.items()):
+        if looks_like_inline_secret(value):
+            env[key] = "${" + str(key) + "}"
+            rewritten.append(str(key))
+    return sorted(rewritten)
+
+
 def _cmd_gateway_export_backends(args) -> int:
     """Export mcpServers block from ~/.claude.json to ~/.hydra/backends.json."""
     from .dispatcher import _load_user_scope_mcp, BACKEND_REGISTRY
@@ -3009,6 +3064,17 @@ def _cmd_gateway_export_backends(args) -> int:
     if not servers:
         print("No mcpServers found in ~/.claude.json")
         return 1
+    # E2-5: never copy inline secret material into backends.json. Any env value
+    # that looks like a 64-hex key is rewritten to a ${VAR} reference resolved
+    # at dispatch time from the launching environment. The value itself is
+    # neither printed nor retained.
+    for _name, _spec in servers.items():
+        _redacted = _redact_inline_secrets(_spec)
+        for _key in _redacted:
+            print(
+                f"  NOTE: {_name}.env.{_key} rewritten to ${{{_key}}} — "
+                f"export {_key} in the environment that launches Hydra."
+            )
     BACKEND_REGISTRY.parent.mkdir(parents=True, exist_ok=True)
     BACKEND_REGISTRY.write_text(
         json.dumps(servers, indent=2, default=str), encoding="utf-8"

--- a/hydra_core/dispatcher.py
+++ b/hydra_core/dispatcher.py
@@ -32,6 +32,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from .backends_env import expand_spec_env
+
 logger = logging.getLogger(__name__)
 
 
@@ -602,6 +604,9 @@ class MCPStdioDispatcher:
                 ),
             }
 
+        # E2-5: resolve ${VAR} / ${VAR:-default} references so a secret can live
+        # in the launching environment instead of inline in backends.json.
+        spec = expand_spec_env(spec, server=server)
         params = StdioServerParameters(
             command=spec["command"],
             args=list(spec.get("args", [])),
@@ -868,6 +873,8 @@ class MCPStdioDispatcher:
             if spec is None:
                 raise KeyError(server)
 
+            # E2-5: same ${VAR} expansion as the one-shot path above.
+            spec = expand_spec_env(spec, server=server)
             params = StdioServerParameters(
                 command=spec["command"],
                 args=list(spec.get("args", [])),

--- a/hydra_core/gateway_templates.json
+++ b/hydra_core/gateway_templates.json
@@ -148,7 +148,8 @@
     "cwd_template": "{HYDRA_ROOT}",
     "env_template": {
       "PYTHONPATH": "{HYDRA_ROOT}",
-      "HYDRA_XENIA_ROOT": "{XENIA_ROOT}"
+      "HYDRA_XENIA_ROOT": "{XENIA_ROOT}",
+      "HYDRA_OPERATOR_KEY": "${HYDRA_OPERATOR_KEY}"
     },
     "check_path_template": "{XENIA_ROOT}",
     "required": false,
@@ -161,7 +162,8 @@
     "cwd_template": "{HYDRA_ROOT}",
     "env_template": {
       "PYTHONPATH": "{HYDRA_ROOT}",
-      "HYDRA_ROOT": "{HYDRA_ROOT}"
+      "HYDRA_ROOT": "{HYDRA_ROOT}",
+      "HYDRA_OPERATOR_KEY": "${HYDRA_OPERATOR_KEY}"
     },
     "check_path_template": "{HYDRA_ROOT}",
     "required": true,

--- a/mcp_servers/hydra_gateway/server.py
+++ b/mcp_servers/hydra_gateway/server.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 _HERE = Path(__file__).resolve()
 sys.path.insert(0, str(_HERE.parents[2]))
 
+from hydra_core.backends_env import expand_spec_env  # noqa: E402
 from hydra_core.dispatcher import BACKEND_REGISTRY, _load_backend_registry, _strip_comments  # noqa: E402
 from hydra_core.toolshed import build_default_shed, ProgressiveDisclosureTree  # noqa: E402
 from hydra_core.squad_loader import discover_squads  # noqa: E402
@@ -158,7 +159,9 @@ class AsyncBackendPool:
         except ImportError:
             return None
 
-        spec = self._specs[server]
+        # E2-5: resolve ${VAR} / ${VAR:-default} references so a secret can live
+        # in the launching environment instead of inline in backends.json.
+        spec = expand_spec_env(self._specs[server], server=server)
         params = StdioServerParameters(
             command=spec["command"],
             args=list(spec.get("args", [])),

--- a/scripts/backends.template.json
+++ b/scripts/backends.template.json
@@ -143,7 +143,8 @@
     "cwd": "{{HYDRA_ROOT}}",
     "env": {
       "PYTHONPATH": "{{HYDRA_ROOT}}",
-      "HYDRA_XENIA_ROOT": "{{AIAPP_BASE}}/Xenia"
+      "HYDRA_XENIA_ROOT": "{{AIAPP_BASE}}/Xenia",
+      "HYDRA_OPERATOR_KEY": "${HYDRA_OPERATOR_KEY}"
     }
   },
   "marketbliss": {
@@ -169,7 +170,8 @@
     "cwd": "{{HYDRA_ROOT}}",
     "env": {
       "PYTHONPATH": "{{HYDRA_ROOT}}",
-      "HYDRA_ROOT": "{{HYDRA_ROOT}}"
+      "HYDRA_ROOT": "{{HYDRA_ROOT}}",
+      "HYDRA_OPERATOR_KEY": "${HYDRA_OPERATOR_KEY}"
     }
   },
   "blender": {

--- a/tests/test_backends_env_expansion.py
+++ b/tests/test_backends_env_expansion.py
@@ -1,0 +1,358 @@
+"""E2-5 — ``${VAR}`` expansion for MCP backend env/args.
+
+Covers the three surfaces the fix touches:
+
+1. the shared helper (``hydra_core.backends_env``) — set / unset / default /
+   escape / inline-secret shape check;
+2. ``MCPStdioDispatcher`` building ``StdioServerParameters`` from an expanded
+   spec, on both the one-shot and pooled paths;
+3. ``hydra doctor`` — WARN on an inline 64-hex value, and ``source=env`` when
+   the operator key arrives through a ``${VAR}`` reference.
+
+No test writes, reads, or asserts on a real secret; the doctor tests use a
+synthetic all-``a`` hex string.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hydra_core.backends_env import (
+    expand_env_refs,
+    expand_spec_env,
+    has_env_ref,
+    looks_like_inline_secret,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Synthetic, non-secret value with the shape of a 64-hex operator key.
+SYNTHETIC_HEX = "a" * 64
+
+
+# ---------------------------------------------------------------------------
+# 1. Helper
+# ---------------------------------------------------------------------------
+
+
+def test_expand_uses_environment_when_variable_is_set():
+    assert expand_env_refs("${E2_5_TOK}", environ={"E2_5_TOK": "resolved"}) == "resolved"
+
+
+def test_expand_missing_variable_yields_empty_string_and_warns(caplog):
+    with caplog.at_level("WARNING"):
+        out = expand_env_refs("${E2_5_ABSENT}", environ={})
+    assert out == ""
+    assert "E2_5_ABSENT" in caplog.text
+
+
+def test_expand_missing_variable_does_not_raise():
+    """Fail-soft: a missing reference must never crash a dispatch."""
+    assert expand_spec_env({"env": {"K": "${E2_5_ABSENT}"}}, environ={}) == {
+        "env": {"K": ""}
+    }
+
+
+def test_default_is_used_when_variable_is_unset_and_never_warns(caplog):
+    with caplog.at_level("WARNING"):
+        out = expand_env_refs("${E2_5_ABSENT:-fallback}", environ={})
+    assert out == "fallback"
+    assert "E2_5_ABSENT" not in caplog.text
+
+
+def test_default_is_ignored_when_variable_is_set():
+    assert (
+        expand_env_refs("${E2_5_TOK:-fallback}", environ={"E2_5_TOK": "real"}) == "real"
+    )
+
+
+def test_empty_variable_falls_back_to_default():
+    assert expand_env_refs("${E2_5_TOK:-fallback}", environ={"E2_5_TOK": ""}) == "fallback"
+
+
+def test_reference_embedded_in_a_larger_string():
+    out = expand_env_refs("prefix:${E2_5_TOK}:suffix", environ={"E2_5_TOK": "mid"})
+    assert out == "prefix:mid:suffix"
+
+
+def test_doubled_sigil_is_a_literal_escape():
+    assert expand_env_refs("$${E2_5_TOK}", environ={"E2_5_TOK": "x"}) == "${E2_5_TOK}"
+    assert has_env_ref("$${E2_5_TOK}") is False
+
+
+def test_non_string_values_pass_through_untouched():
+    assert expand_env_refs(7) == 7
+    assert expand_env_refs(None) is None
+
+
+def test_expand_spec_env_does_not_mutate_the_input_spec():
+    spec = {"env": {"K": "${E2_5_TOK}"}, "args": ["${E2_5_TOK}"]}
+    out = expand_spec_env(spec, environ={"E2_5_TOK": "v"})
+    assert spec["env"]["K"] == "${E2_5_TOK}"
+    assert spec["args"] == ["${E2_5_TOK}"]
+    assert out["env"]["K"] == "v"
+    assert out["args"] == ["v"]
+
+
+def test_expand_spec_env_covers_args_command_and_cwd():
+    out = expand_spec_env(
+        {
+            "command": "${E2_5_BIN}",
+            "args": ["-m", "${E2_5_MOD}"],
+            "cwd": "${E2_5_ROOT}",
+            "env": {"PLAIN": "no-refs-here"},
+        },
+        environ={"E2_5_BIN": "python", "E2_5_MOD": "pkg", "E2_5_ROOT": "/w"},
+    )
+    assert out["command"] == "python"
+    assert out["args"] == ["-m", "pkg"]
+    assert out["cwd"] == "/w"
+    assert out["env"]["PLAIN"] == "no-refs-here"
+
+
+def test_env_keys_are_never_expanded():
+    out = expand_spec_env({"env": {"${E2_5_TOK}": "v"}}, environ={"E2_5_TOK": "x"})
+    assert list(out["env"]) == ["${E2_5_TOK}"]
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (SYNTHETIC_HEX, True),
+        (SYNTHETIC_HEX.upper(), True),
+        (f"  {SYNTHETIC_HEX}  ", True),
+        ("a" * 63, False),
+        ("a" * 65, False),
+        ("${HYDRA_OPERATOR_KEY}", False),
+        ("/some/path", False),
+        (None, False),
+        (12345, False),
+    ],
+)
+def test_inline_secret_shape_check(value, expected):
+    assert looks_like_inline_secret(value) is expected
+
+
+def test_helper_reads_os_environ_when_no_mapping_is_given(monkeypatch):
+    monkeypatch.setenv("E2_5_FROM_OS", "os-value")
+    assert expand_env_refs("${E2_5_FROM_OS}") == "os-value"
+
+
+# ---------------------------------------------------------------------------
+# 2. Dispatcher builds StdioServerParameters from an expanded spec
+# ---------------------------------------------------------------------------
+
+
+def _captured_params_for(spec: dict, monkeypatch, pooled: bool):
+    """Drive the dispatcher far enough to capture its StdioServerParameters."""
+    from hydra_core.dispatcher import MCPStdioDispatcher
+
+    captured: dict = {}
+
+    class _FakeParams:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    import mcp as _mcp
+
+    monkeypatch.setattr(_mcp, "StdioServerParameters", _FakeParams, raising=False)
+
+    disp = MCPStdioDispatcher(REPO_ROOT)
+    disp._servers = {"e2_5_backend": spec}
+
+    def _boom(*_a, **_kw):
+        # Raises synchronously so the dispatcher unwinds right after it has
+        # built StdioServerParameters — no transport is ever opened.
+        raise RuntimeError("stop-after-params")
+
+    import mcp.client.stdio as _stdio
+
+    monkeypatch.setattr(_stdio, "stdio_client", _boom, raising=False)
+
+    coro = (
+        disp._get_or_connect_pooled_session("e2_5_backend")
+        if pooled
+        else disp._async_call("e2_5_backend", "noop", {})
+    )
+    import asyncio
+
+    try:
+        asyncio.run(coro)
+    except Exception:
+        pass
+    return captured
+
+
+@pytest.mark.parametrize("pooled", [False, True])
+def test_dispatcher_passes_expanded_env_to_stdio_params(monkeypatch, pooled):
+    monkeypatch.setenv("E2_5_DISPATCH_TOK", "from-parent-env")
+    spec = {
+        "command": "python",
+        "args": ["-m", "pkg", "--root=${E2_5_DISPATCH_TOK}"],
+        "env": {
+            "SECRET_REF": "${E2_5_DISPATCH_TOK}",
+            "WITH_DEFAULT": "${E2_5_UNSET_HERE:-fallback}",
+            "PLAIN": "literal",
+        },
+        "cwd": ".",
+    }
+    captured = _captured_params_for(spec, monkeypatch, pooled=pooled)
+
+    assert captured, "dispatcher never built StdioServerParameters"
+    assert captured["env"]["SECRET_REF"] == "from-parent-env"
+    assert captured["env"]["WITH_DEFAULT"] == "fallback"
+    assert captured["env"]["PLAIN"] == "literal"
+    assert captured["args"][-1] == "--root=from-parent-env"
+    # The registry's own dict must be untouched.
+    assert spec["env"]["SECRET_REF"] == "${E2_5_DISPATCH_TOK}"
+
+
+def test_dispatcher_missing_reference_does_not_crash_param_build(monkeypatch):
+    monkeypatch.delenv("E2_5_NEVER_SET", raising=False)
+    spec = {
+        "command": "python",
+        "args": [],
+        "env": {"SECRET_REF": "${E2_5_NEVER_SET}"},
+    }
+    captured = _captured_params_for(spec, monkeypatch, pooled=False)
+    assert captured["env"]["SECRET_REF"] == ""
+
+
+# ---------------------------------------------------------------------------
+# 3. hydra doctor
+# ---------------------------------------------------------------------------
+
+
+def _run_doctor_with_backends(backends: dict, tmp_path, monkeypatch, capsys):
+    """Run full-mode `hydra doctor` against a synthetic ~/.hydra/backends.json.
+
+    The WS-AUTH probe lives past the `--quick` cut-off, so the MCP probes and
+    the eights spool are stubbed out the same way the RA-6 doctor tests do.
+    """
+    from hydra_core import cli
+
+    fake_home = tmp_path / "home"
+    (fake_home / ".hydra").mkdir(parents=True)
+    (fake_home / ".hydra" / "backends.json").write_text(
+        json.dumps(backends), encoding="utf-8"
+    )
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    class _MockDispatcher:
+        def call_mcp(self, server, tool, args, **_kw):
+            return {"status": "failed", "error": "not_registered"}
+
+    class _EmptySpool:
+        def count(self):
+            return 0
+
+    with patch(
+        "hydra_core.dispatcher.MCPStdioDispatcher", return_value=_MockDispatcher()
+    ), patch("hydra_core.dispatcher._load_mcp_config", return_value={}), patch(
+        "hydra_core.eights.pending_spool.PendingSpool", return_value=_EmptySpool()
+    ):
+        rc = cli.main(["--project", str(REPO_ROOT), "doctor"])
+    return rc, capsys.readouterr().out
+
+
+def test_doctor_warns_when_backends_json_holds_an_inline_hex_value(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.delenv("HYDRA_OPERATOR_KEY", raising=False)
+    backends = {
+        "xenia_tickets": {
+            "command": "python",
+            "args": [],
+            "env": {"HYDRA_OPERATOR_KEY": SYNTHETIC_HEX},
+        }
+    }
+    rc, out = _run_doctor_with_backends(backends, tmp_path, monkeypatch, capsys)
+
+    assert rc in (0, 1)
+    assert "inline secret-shaped" in out
+    assert "xenia_tickets.env.HYDRA_OPERATOR_KEY" in out
+    # The value itself must never be printed.
+    assert SYNTHETIC_HEX not in out
+    assert "source=backends.json" in out
+
+
+def test_doctor_reports_source_env_for_a_var_reference(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HYDRA_OPERATOR_KEY", SYNTHETIC_HEX)
+    backends = {
+        "xenia_tickets": {
+            "command": "python",
+            "args": [],
+            "env": {"HYDRA_OPERATOR_KEY": "${HYDRA_OPERATOR_KEY}"},
+        }
+    }
+    rc, out = _run_doctor_with_backends(backends, tmp_path, monkeypatch, capsys)
+
+    assert rc in (0, 1)
+    assert "source=env" in out
+    assert "source=backends.json" not in out
+    assert "inline secret-shaped" not in out
+    assert SYNTHETIC_HEX not in out
+
+
+def test_doctor_var_reference_without_the_variable_stays_unprovisioned(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.delenv("HYDRA_OPERATOR_KEY", raising=False)
+    backends = {
+        "xenia_tickets": {
+            "command": "python",
+            "args": [],
+            "env": {"HYDRA_OPERATOR_KEY": "${HYDRA_OPERATOR_KEY}"},
+        }
+    }
+    rc, out = _run_doctor_with_backends(backends, tmp_path, monkeypatch, capsys)
+
+    assert rc in (0, 1)
+    assert "WS-AUTH operator key unprovisioned" in out
+
+
+# ---------------------------------------------------------------------------
+# 4. Export rewrites inline secrets to references
+# ---------------------------------------------------------------------------
+
+
+def test_export_backends_rewrites_inline_secret_to_a_reference(tmp_path, capsys):
+    from hydra_core import cli
+
+    out_path = tmp_path / "backends.json"
+    servers = {
+        "xenia_tickets": {
+            "command": "python",
+            "args": ["-m", "mcp_servers.xenia_tickets"],
+            "env": {"HYDRA_OPERATOR_KEY": SYNTHETIC_HEX, "PYTHONPATH": "/x"},
+        }
+    }
+
+    with patch("hydra_core.dispatcher._load_user_scope_mcp", return_value=servers), \
+         patch("hydra_core.dispatcher.BACKEND_REGISTRY", out_path):
+        rc = cli._cmd_gateway_export_backends(object())
+
+    assert rc == 0
+    written = json.loads(out_path.read_text(encoding="utf-8"))
+    assert written["xenia_tickets"]["env"]["HYDRA_OPERATOR_KEY"] == (
+        "${HYDRA_OPERATOR_KEY}"
+    )
+    assert written["xenia_tickets"]["env"]["PYTHONPATH"] == "/x"
+    assert SYNTHETIC_HEX not in out_path.read_text(encoding="utf-8")
+    assert SYNTHETIC_HEX not in capsys.readouterr().out
+
+
+def test_gateway_templates_reference_the_operator_key_by_variable():
+    templates = json.loads(
+        (REPO_ROOT / "hydra_core" / "gateway_templates.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    for name in ("hydra_control", "xenia_tickets"):
+        env = templates[name]["env_template"]
+        assert env["HYDRA_OPERATOR_KEY"] == "${HYDRA_OPERATOR_KEY}"
+        assert not looks_like_inline_secret(env["HYDRA_OPERATOR_KEY"])


### PR DESCRIPTION
Backend specs handed their `env` map verbatim to the stdio child, so the only way to give a backend a secret was to write it inline into `~/.hydra/backends.json` — a plaintext file every dispatcher reads and `hydra gateway-backup` copies.

## What changed

- **`hydra_core/backends_env.py` (new)** — one shared expander for `${VAR}` and `${VAR:-default}`, with `$${VAR}` as a literal escape. A missing variable without a default logs a WARNING naming the variable and substitutes the empty string: fail-soft, never a crash mid-dispatch.
- **Both stdio call sites use it** — the gateway backend pool and `MCPStdioDispatcher` (one-shot and pooled paths) expand the spec before building `StdioServerParameters`, so the two cannot drift. `args`, `command`, and `cwd` expand too. The registry's own dict is never mutated.
- **Templates reference the key instead of carrying a value** — `gateway_templates.json` and `scripts/backends.template.json` template `HYDRA_OPERATOR_KEY` as `"${HYDRA_OPERATOR_KEY}"` for `hydra_control` and `xenia_tickets`. Neither placeholder mechanism (`{KEY}` / `{{KEY}}`) touches the `${...}` form.
- **`hydra gateway-export-backends`** rewrites any inline 64-hex env value it copies into the matching `${VAR}` reference.
- **`hydra doctor`** reports `source=env` when the operator key arrives through a reference that resolves, `source=backends.json` only when it is still literal, and WARNs naming the backend and key when the file holds an inline secret-shaped value. Both are shape checks; no value is ever printed or logged.
- **`docs/MCP_SETUP.md`** — new "Referencing secrets from the environment" subsection.

## Tests

| Scope | Result |
|---|---|
| `tests/test_backends_env_expansion.py` (new) | 30 passed |
| `-k "gateway or dispatcher or doctor"` | 143 passed |
| Full suite | 1707 passed, 2 failed, 4 skipped |

The 30 new tests cover the expander (set, unset, default, escape, no-mutation), the dispatcher building params from an expanded spec on both paths, doctor's warn and source reporting, and the export rewrite. Every test uses a synthetic all-`a` hex value; no real key material appears anywhere.

The two full-suite failures are the known worktree-environmental ones in `test_native_pack_dispatch.py` and `test_claude_native_configuration.py` (the `marketing-*` symlinks do not resolve inside a worktree). They fail identically without this change and are unrelated to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
