### PR TITLE
E2-32: attended route for stub squads + deterministic approval

### DIFF
--- a/hydra_core/cli.py
+++ b/hydra_core/cli.py
@@ -1532,6 +1532,157 @@ def _next_nonengineering_attended_task(state: HydraState, packs: dict):
     return None, None
 
 
+def _next_stub_attended_task(state: HydraState, packs: dict):
+    """E2-32: first pending task (task-list order) owned by a squad whose pack
+    entrypoint is ``stub``, that the host has not yet completed.
+
+    A stub squad has no host action to spawn and no MCP leg to drive — its
+    whole contract is the canned ``[STUB]`` DecisionRecord that
+    ``squad_node._stub`` returns. Before this, ``_next_engineering_task`` and
+    ``_next_nonengineering_attended_task`` both skipped stub tasks, so an
+    attended workflow whose only task was a stub squad reported
+    ``no_pending_task`` forever and never advanced.
+    """
+    done = set(getattr(state, "attended_completed_task_ids", []) or [])
+    for t in getattr(state, "tasks", []):
+        if str(t.task_id) in done:
+            continue
+        pack = packs.get(t.owner_squad)
+        if pack is not None and getattr(pack, "entrypoint", None) == "stub":
+            return t, pack
+    return None, None
+
+
+def _task_precedes(state: HydraState, task, other) -> bool:
+    """True when `task` comes before `other` in the workflow's task list.
+    A None `other` (no competing candidate) means `task` wins by default."""
+    if other is None:
+        return True
+    order = [str(t.task_id) for t in getattr(state, "tasks", [])]
+    try:
+        return order.index(str(task.task_id)) < order.index(str(other.task_id))
+    except ValueError:  # pragma: no cover — both ids come from state.tasks
+        return True
+
+
+def _drive_stub_task(sup, config: dict, project: Path, wf: str,
+                     state: HydraState, task, pack) -> dict:
+    """E2-32: run a stub squad's in-process path and record it as the task
+    result, with the same checkpoint bookkeeping ``submit-host-result`` does
+    for a squad result.
+
+    Idempotent with the in-graph path: when a headless dispatch pass already
+    produced this squad's ``[STUB]`` DecisionRecord (RA-5 keeps stubs OUT of
+    the live-defer pre-filter, so ``node_dispatch`` runs ``_stub`` itself), the
+    existing envelope is reused instead of emitting a second one. The task is
+    marked attended-complete but deliberately NOT added to
+    ``attended_done_task_ids`` — a stub is `surfaced`, not `done`, and
+    ``enforce_governance`` must keep surfacing the workflow for human
+    follow-up.
+    """
+    from .squad_node import _stub
+    from .schemas import CSuiteDecisionPacket
+
+    task_id = str(task.task_id)
+    existing: dict | None = None
+    for e in getattr(state, "envelopes", []) or []:
+        if not isinstance(e, dict):
+            continue
+        if (e.get("origin_squad") == pack.slug
+                and "[STUB]" in str(e.get("decision") or "")):
+            existing = e
+            break
+
+    new_envelopes: list[dict] = []
+    if existing is None:
+        inbound = CSuiteDecisionPacket(
+            workflow_id=state.workflow_id,
+            origin_squad="hydra",
+            target_squad=pack.slug,
+            origin="BOARDROOM",
+            objective=task.description or state.root_goal,
+        )
+        result = _stub(pack, inbound)
+        from .ingest import _redact_envelope_dict
+        for produced in result.envelopes:
+            d = _redact_envelope_dict(produced.model_dump(mode="json"))
+            d["_task_id"] = task_id
+            new_envelopes.append(d)
+        existing = new_envelopes[0] if new_envelopes else None
+
+    completed = list(getattr(state, "attended_completed_task_ids", []) or [])
+    if task_id not in completed:
+        completed.append(task_id)
+    patch: dict = {"attended_completed_task_ids": completed}
+    if new_envelopes:
+        # `envelopes` uses an append reducer — emit only the NEW records.
+        patch["envelopes"] = new_envelopes
+    try:
+        sup.update_state(config, patch)
+    except Exception as e:  # noqa: BLE001
+        emit(project, wf, "attended.persist_failed", {"error": str(e)})
+
+    envelope_id = (str(existing.get("id"))
+                   if isinstance(existing, dict) and existing.get("id") is not None
+                   else None)
+    emit(project, wf, "dispatch.stub_surfaced", {
+        "task_id": task_id,
+        "squad_slug": pack.slug,
+        "entrypoint": "stub",
+        "envelope_id": envelope_id,
+        "reused_in_graph_record": not new_envelopes,
+    })
+    return {
+        "status": "stub_surfaced",
+        "task_id": task_id,
+        "squad_slug": pack.slug,
+        "envelope_id": envelope_id,
+        "decision_record": existing,
+    }
+
+
+def _run_first_step_dispatch_pass(sup, config: dict, project: Path, wf: str,
+                                  snap, state: HydraState) -> bool:
+    """E2-32: run the headless dispatch pass `hydra approve` runs, on the FIRST
+    attended step of a workflow that has no approval gate.
+
+    ``hydra plan`` adds ``dispatch`` to ``interrupt_before``, so every planned
+    workflow parks at a bare interrupt. A gated workflow leaves that interrupt
+    via ``/hydra:approve``; a workflow whose planner set
+    ``requires_human_approval=False`` had NO caller for that pass at all, so
+    claude-skill / agent-impersonation tasks never got their
+    ``dispatch.deferred_to_host`` marking and the phase never left ``dispatch``.
+
+    Guards (all required): a bare LangGraph interrupt is pending, no HITL gate
+    is open, the planner did not require approval, and nothing has been driven
+    attended yet (this is a first-step bootstrap, not a per-step resume).
+    A pending engineering task suppresses the pass — the attended engineering
+    cursor below owns that dispatch and engineering deferral semantics are out
+    of scope here (fix-E2-22).
+
+    Returns True when the pass ran, so the caller re-reads the checkpoint.
+    """
+    if getattr(state, "requires_human_approval", False):
+        return False
+    if state.pending_hitl:
+        return False
+    if getattr(state, "attended_completed_task_ids", None):
+        return False
+    if not (getattr(snap, "next", ()) or ()):
+        return False
+    if _next_engineering_task(state) is not None:
+        return False
+    emit(project, wf, "attended.no_approval_dispatch_pass", {
+        "interrupted_before": list(getattr(snap, "next", ()) or ()),
+    })
+    try:
+        sup.invoke(None, config=config)
+    except Exception as e:  # noqa: BLE001 — the attended cursor still proceeds
+        emit(project, wf, "attended.dispatch_pass_failed", {"error": str(e)})
+        return False
+    return True
+
+
 def _resolve_pack_lead_agent(pack) -> str:
     """Resolve the supervisor / lead agent slug for a squad pack.
 
@@ -1664,6 +1815,13 @@ def _cmd_attended_step(args) -> int:
                   file=sys.stderr)
             return 1
         state = HydraState.model_validate(snap.values)
+
+        # E2-32: no-approval workflows have no `approve` caller to leave the
+        # plan_only dispatch interrupt — run that same pass here, once.
+        if _run_first_step_dispatch_pass(sup, config, project, wf, snap, state):
+            snap = sup.get_state(config)
+            if snap is not None and snap.values:
+                state = HydraState.model_validate(snap.values)
 
         # --- Engineering task (mcp entrypoint) ---
         task = _next_engineering_task(state)
@@ -1802,7 +1960,20 @@ def _cmd_attended_step(args) -> int:
 
         # --- Non-engineering task (claude-skill / agent-impersonation) ---
         packs = _discover(project)
+
         ne_task, ne_pack = _next_nonengineering_attended_task(state, packs)
+
+        # E2-32: a stub squad has no host action to spawn — drive it in-process.
+        # Resolved against the squad cursor in TASK-LIST ORDER: whichever of the
+        # two candidates appears first in state.tasks wins, so a stub never
+        # jumps the queue and is never skipped forever.
+        stub_task, stub_pack = _next_stub_attended_task(state, packs)
+        if stub_task is not None and _task_precedes(state, stub_task, ne_task):
+            res = _drive_stub_task(sup, config, project, wf, state,
+                                   stub_task, stub_pack)
+            print(json.dumps({"ok": True, **res}, indent=2, default=str))
+            return 0
+
         if ne_task is not None:
             task_id = str(ne_task.task_id)
             request_text = ne_task.description or state.root_goal

--- a/hydra_core/supervisor.py
+++ b/hydra_core/supervisor.py
@@ -1172,7 +1172,17 @@ def build_supervisor(
 
         # (a) requires_human_approval: any high-risk task anywhere in full_tasks.
         high_risk = any(_task_is_high_risk(t) for t in full_tasks)
-        state.requires_human_approval = high_risk or state.is_over_budget()
+        # E2-32: an UNFUNDED workflow (budget_usd == 0) is not a risk signal.
+        # `is_over_budget()` is `spent >= budget`, which is trivially True for
+        # budget_usd == 0.0 at spent 0.0 -- so the identical goal/squad/risk
+        # required approval at --budget 0 and did not at --budget 0.1. Budget
+        # exhaustion is the dispatch-time gate (`budget.pre_dispatch_block` in
+        # node_dispatch, which fires on the same `spent >= budget` predicate
+        # and includes the zero-budget case); the approval gate stays purely
+        # risk-driven. A funded workflow that is genuinely over budget before
+        # dispatch still requires approval, exactly as before.
+        budget_exhausted = state.budget.budget_usd > 0 and state.is_over_budget()
+        state.requires_human_approval = high_risk or budget_exhausted
 
         # squad_gate_high_risk: True when any task's squad has an explicit
         # hitl_required gate (independent of task priority).  This is the

--- a/tests/test_attended_stub_route_e2_32.py
+++ b/tests/test_attended_stub_route_e2_32.py
@@ -1,0 +1,345 @@
+"""E2-32: attended mode must have a route for stub squads and for workflows
+that need no approval, and the approval decision must not flip on budget == 0.
+
+Three regressions, one finding:
+
+1. `_next_engineering_task` accepts only engineering and
+   `_next_nonengineering_attended_task` only claude-skill / claude-native /
+   agent-impersonation, so a task owned by a `stub`-entrypoint squad was
+   invisible to `hydra attended step` -- the workflow reported
+   `no_pending_task` forever and never produced the `[STUB]` DecisionRecord
+   that `tests/test_stub_surface_ra5.py` pins for the headless path.
+2. `hydra plan` parks every workflow at the plan_only `dispatch` interrupt.
+   A gated workflow leaves it via `/hydra:approve`; a workflow with
+   `requires_human_approval=False` had no caller for that pass at all.
+3. `requires_human_approval` was `high_risk or is_over_budget()`, and
+   `is_over_budget()` is `spent >= budget` -- trivially True at budget 0.0.
+   The identical goal/squad/risk therefore required approval at --budget 0 and
+   did not at --budget 0.1.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from hydra_core import cli
+from hydra_core.state import HydraState, TaskState
+
+HYDRA_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# fakes
+# ---------------------------------------------------------------------------
+
+class _StubPack:
+    slug = "healthcare"
+    name = "Healthcare"
+    entrypoint = "stub"
+    agents: list = []
+    gates: list = []
+
+
+class _SkillPack:
+    class _Agent:
+        slug = "boardroom"
+        authority = "gatekeeper"
+
+    slug = "executive"
+    name = "Executive"
+    entrypoint = "agent-impersonation"
+    agents = [_Agent()]
+    gates: list = []
+
+
+class _NopDispatcher:
+    live_execution = True
+
+    def call_mcp(self, server, tool, args, **_kw):
+        return {"status": "done", "result": {}}
+
+    def set_squad_packs(self, packs):
+        pass
+
+
+class _FakeSup:
+    """Minimal checkpointer stand-in: one mutable state dict, LangGraph-shaped
+    `next` tuple, and an `envelopes` channel with the real append semantics."""
+
+    def __init__(self, state: HydraState, next_nodes: tuple[str, ...] = ()):
+        self.values = state.model_dump(mode="json")
+        self._next = next_nodes
+        self.updates: list[dict] = []
+        self.invoked = 0
+
+    # -- checkpoint surface --------------------------------------------------
+    def get_state(self, config):
+        outer = self
+
+        class _Snap:
+            values = outer.values
+            next = outer._next
+
+        return _Snap()
+
+    def update_state(self, config, values):
+        self.updates.append(dict(values))
+        for key, val in values.items():
+            if key == "envelopes":            # append reducer
+                self.values.setdefault("envelopes", []).extend(val)
+            else:                             # replace channel
+                self.values[key] = val
+
+    def invoke(self, _inp, config=None):
+        self.invoked += 1
+        self._next = ()
+        self.values["phase"] = "executing"
+        return self.values
+
+
+def _install(monkeypatch, sup, packs):
+    monkeypatch.setattr("hydra_core.cli._attended_live_dispatcher",
+                        lambda *a, **k: _NopDispatcher())
+    monkeypatch.setattr("hydra_core.supervisor.build_supervisor",
+                        lambda **k: sup)
+    monkeypatch.setattr("hydra_core.squad_loader.discover_squads",
+                        lambda *a, **k: packs)
+
+
+def _step(tmp_path, wf_id, capsys):
+    rc = cli._cmd_attended_step(argparse.Namespace(
+        project=str(tmp_path), workflow_id=wf_id, verbose=False))
+    out = capsys.readouterr().out
+    assert rc == 0, f"attended step failed (rc={rc}): {out[:400]}"
+    return json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# 1. stub-only attended workflow
+# ---------------------------------------------------------------------------
+
+def test_attended_step_drives_stub_squad_in_process(tmp_path, monkeypatch, capsys):
+    """A stub-only workflow yields `stub_surfaced` with a [STUB]
+    DecisionRecord, and the task is marked attended-complete."""
+    task = TaskState(owner_squad="healthcare", description="assess readiness")
+    state = HydraState(root_goal="assess readiness", tasks=[task])
+    wf_id = str(state.workflow_id)
+    sup = _FakeSup(state)
+    _install(monkeypatch, sup, {"healthcare": _StubPack()})
+
+    payload = _step(tmp_path, wf_id, capsys)
+
+    assert payload["status"] == "stub_surfaced", payload
+    assert payload["task_id"] == str(task.task_id)
+    assert payload["squad_slug"] == "healthcare"
+    assert payload["envelope_id"], "stub_surfaced must carry the envelope id"
+    assert "[STUB]" in payload["decision_record"]["decision"]
+    assert payload["decision_record"]["type"] == "DECISION_RECORD"
+
+    # bookkeeping: attended-complete + the record persisted on the checkpoint
+    assert str(task.task_id) in sup.values["attended_completed_task_ids"]
+    stub_envs = [e for e in sup.values["envelopes"]
+                 if "[STUB]" in str(e.get("decision") or "")]
+    assert len(stub_envs) == 1, sup.values["envelopes"]
+
+    # the loop then continues: nothing left to drive
+    nxt = _step(tmp_path, wf_id, capsys)
+    assert nxt["status"] == "no_pending_task", nxt
+
+
+def test_stub_task_is_not_marked_done_so_governance_still_surfaces(
+        tmp_path, monkeypatch, capsys):
+    """A stub is `surfaced`, never `done`: it must stay OUT of
+    attended_done_task_ids so enforce_governance keeps surfacing the workflow
+    for human follow-up."""
+    task = TaskState(owner_squad="healthcare", description="assess readiness")
+    state = HydraState(root_goal="assess readiness", tasks=[task])
+    sup = _FakeSup(state)
+    _install(monkeypatch, sup, {"healthcare": _StubPack()})
+
+    _step(tmp_path, str(state.workflow_id), capsys)
+
+    assert sup.values.get("attended_done_task_ids") in (None, [])
+
+
+def test_stub_drive_reuses_an_in_graph_stub_record(tmp_path, monkeypatch, capsys):
+    """Idempotent with the RA-5 in-graph path: when node_dispatch already
+    emitted this squad's [STUB] record, no second one is created."""
+    task = TaskState(owner_squad="healthcare", description="assess readiness")
+    state = HydraState(root_goal="assess readiness", tasks=[task])
+    existing_id = str(uuid4())
+    state.envelopes = [{
+        "id": existing_id,
+        "type": "DECISION_RECORD",
+        "workflow_id": str(state.workflow_id),
+        "origin_squad": "healthcare",
+        "target_squad": "hydra",
+        "decision": "[STUB] Healthcare not yet implemented",
+        "rationale": "already surfaced in-graph",
+    }]
+    sup = _FakeSup(state)
+    _install(monkeypatch, sup, {"healthcare": _StubPack()})
+
+    payload = _step(tmp_path, str(state.workflow_id), capsys)
+
+    assert payload["envelope_id"] == existing_id
+    stub_envs = [e for e in sup.values["envelopes"]
+                 if "[STUB]" in str(e.get("decision") or "")]
+    assert len(stub_envs) == 1, "the in-graph record must be reused, not duplicated"
+
+
+# ---------------------------------------------------------------------------
+# 2. mixed task list — stub first, then the squad cursor
+# ---------------------------------------------------------------------------
+
+def test_mixed_stub_then_squad_cursor(tmp_path, monkeypatch, capsys):
+    """[stub, executive]: the stub is handled first (task-list order), then the
+    executive squad cursor opens."""
+    stub_task = TaskState(owner_squad="healthcare", description="assess readiness")
+    exec_task = TaskState(owner_squad="executive", description="frame the decision")
+    state = HydraState(root_goal="assess and frame",
+                       tasks=[stub_task, exec_task])
+    wf_id = str(state.workflow_id)
+    sup = _FakeSup(state)
+    _install(monkeypatch, sup, {"healthcare": _StubPack(), "executive": _SkillPack()})
+
+    first = _step(tmp_path, wf_id, capsys)
+    assert first["status"] == "stub_surfaced"
+    assert first["task_id"] == str(stub_task.task_id)
+
+    second = _step(tmp_path, wf_id, capsys)
+    assert second["state"] == "await_squad_agent", second
+    assert second["host_action"]["agent_type"] == "boardroom"
+    assert second["run_id"] == str(exec_task.task_id)
+
+
+def test_squad_cursor_wins_when_it_precedes_the_stub(tmp_path, monkeypatch, capsys):
+    """[executive, stub]: the stub must not jump the queue."""
+    exec_task = TaskState(owner_squad="executive", description="frame the decision")
+    stub_task = TaskState(owner_squad="healthcare", description="assess readiness")
+    state = HydraState(root_goal="frame and assess",
+                       tasks=[exec_task, stub_task])
+    sup = _FakeSup(state)
+    _install(monkeypatch, sup, {"healthcare": _StubPack(), "executive": _SkillPack()})
+
+    first = _step(tmp_path, str(state.workflow_id), capsys)
+    assert first.get("state") == "await_squad_agent", first
+    assert first["run_id"] == str(exec_task.task_id)
+
+
+# ---------------------------------------------------------------------------
+# 3. no-approval workflow reaches a dispatch pass
+# ---------------------------------------------------------------------------
+
+def test_first_step_runs_dispatch_pass_when_no_approval_gate(
+        tmp_path, monkeypatch, capsys):
+    """requires_human_approval=False + a bare interrupt → the first attended
+    step runs the same headless pass `hydra approve` runs."""
+    task = TaskState(owner_squad="healthcare", description="assess readiness")
+    state = HydraState(root_goal="assess readiness", tasks=[task],
+                       requires_human_approval=False)
+    sup = _FakeSup(state, next_nodes=("dispatch",))
+    _install(monkeypatch, sup, {"healthcare": _StubPack()})
+
+    _step(tmp_path, str(state.workflow_id), capsys)
+
+    assert sup.invoked == 1, "the no-approval dispatch pass did not run"
+
+
+def test_dispatch_pass_is_not_rerun_on_later_steps(tmp_path, monkeypatch, capsys):
+    """It is a first-step bootstrap: once anything is attended-complete the
+    pass must not fire again."""
+    task = TaskState(owner_squad="healthcare", description="assess readiness")
+    other = TaskState(owner_squad="executive", description="frame it")
+    state = HydraState(root_goal="assess", tasks=[task, other],
+                       requires_human_approval=False,
+                       attended_completed_task_ids=[str(task.task_id)])
+    sup = _FakeSup(state, next_nodes=("dispatch",))
+    _install(monkeypatch, sup, {"healthcare": _StubPack(), "executive": _SkillPack()})
+
+    _step(tmp_path, str(state.workflow_id), capsys)
+
+    assert sup.invoked == 0
+
+
+def test_dispatch_pass_skipped_when_a_gate_is_open(tmp_path, monkeypatch, capsys):
+    """An open HITL gate resumes only via /hydra:approve or /hydra:resume —
+    the attended step must never resume it."""
+    task = TaskState(owner_squad="healthcare", description="assess readiness")
+    state = HydraState(root_goal="assess readiness", tasks=[task],
+                       requires_human_approval=True)
+    state.pending_hitl = {"reason": "high_risk", "gate_node": "approval"}
+    sup = _FakeSup(state, next_nodes=("approval",))
+    _install(monkeypatch, sup, {"healthcare": _StubPack()})
+
+    _step(tmp_path, str(state.workflow_id), capsys)
+
+    assert sup.invoked == 0, "attended step must not resume a gated workflow"
+
+
+def test_dispatch_pass_skipped_while_engineering_is_pending(
+        tmp_path, monkeypatch, capsys):
+    """Engineering deferral is out of scope (fix-E2-22): a pending engineering
+    task suppresses the pass so the attended engineering cursor stays
+    authoritative."""
+    eng = TaskState(owner_squad="engineering", description="implement it",
+                    target_repo_id="hydra")
+    state = HydraState(root_goal="implement it", tasks=[eng],
+                       requires_human_approval=False)
+    sup = _FakeSup(state, next_nodes=("dispatch",))
+    _install(monkeypatch, sup, {"engineering": _StubPack()})
+    # No agent stubs on disk → the engineering branch exits with the
+    # missing_agent_dependency error; all this test pins is that the dispatch
+    # pass did not fire before it.
+    cli._cmd_attended_step(argparse.Namespace(
+        project=str(tmp_path), workflow_id=str(state.workflow_id), verbose=False))
+    capsys.readouterr()
+
+    assert sup.invoked == 0
+
+
+# ---------------------------------------------------------------------------
+# 4. approval determinism across budgets
+# ---------------------------------------------------------------------------
+
+def _plan_requires_approval(budget: float, *, spent: float = 0.0) -> bool:
+    """Run intake+planner for a fixed goal/squad/risk at the given budget."""
+    from hydra_core.supervisor import build_supervisor
+
+    runner = build_supervisor(
+        project_root=HYDRA_ROOT,
+        dispatcher=cli._NullDispatcher(),
+        force_pure_python=True,
+    )
+    state = HydraState(
+        root_goal="Assess the ops console for clinical deployment readiness",
+        selected_squads=["healthcare"],
+    )
+    state.budget.budget_usd = budget
+    state.budget.spent_usd = spent
+    out = runner.invoke(state)
+    final = HydraState.model_validate(out) if isinstance(out, dict) else out
+    return bool(final.requires_human_approval)
+
+
+def test_zero_budget_does_not_flip_the_approval_gate() -> None:
+    """E2-32 evidence 3: the same goal / squad / risk must yield the same
+    requires_human_approval at budget 0 and 0.1. Zero budget is a
+    dispatch-time gate (budget.pre_dispatch_block), not a risk signal."""
+    at_zero = _plan_requires_approval(0.0)
+    at_tenth = _plan_requires_approval(0.1)
+    at_five = _plan_requires_approval(5.0)
+    assert at_zero == at_tenth == at_five, (
+        f"requires_human_approval flipped on budget alone: "
+        f"0={at_zero} 0.1={at_tenth} 5.0={at_five}"
+    )
+
+
+def test_funded_workflow_over_budget_still_requires_approval() -> None:
+    """The guard is `budget_usd > 0 and is_over_budget()` — a funded workflow
+    that is genuinely exhausted before dispatch still gates."""
+    assert _plan_requires_approval(1.0, spent=1.0) is True


### PR DESCRIPTION
Fixes finding E2-32: three squads (healthcare, sales-gtm, research-ds) were unreachable interactively, and workflows silently stranded at `dispatch`.

## 1. Attended route for stub squads

`hydra attended step` had no cursor for a `stub`-entrypoint squad: `_next_engineering_task` accepts only engineering, `_next_nonengineering_attended_task` only claude-skill / claude-native / agent-impersonation. A stub task was invisible, so the step returned `no_pending_task` forever and the `[STUB]` DecisionRecord (pinned for the headless path by `tests/test_stub_surface_ra5.py`) was never produced.

New helper `_drive_stub_task` runs `squad_node._stub` in-process, validates and redacts the record at the squad boundary, persists it on the checkpoint, appends the task to `attended_completed_task_ids`, emits `dispatch.stub_surfaced`, and returns `{status:"stub_surfaced", task_id, squad_slug, envelope_id}` so the loop continues to the next task. Two deliberate properties:

- **Idempotent with the in-graph path.** RA-5 keeps stubs out of the live-defer pre-filter, so `node_dispatch` runs `_stub` itself. When that record already exists it is reused instead of emitting a second one.
- **Not marked done.** A stub is `surfaced`, not `done`, so the task stays out of `attended_done_task_ids` and `enforce_governance` keeps surfacing the workflow for human follow-up.

Selection resolves against the squad cursor in task-list order (`_task_precedes`), so a stub neither jumps the queue nor is skipped forever.

## 2. Root cause of the approval flip

`node_planner` set `requires_human_approval = high_risk or state.is_over_budget()`. `is_over_budget()` is `spent >= budget`, which is trivially True for `budget_usd == 0.0` at `spent 0.0`. The same goal/squad/risk therefore required approval at `--budget 0` and did not at `--budget 0.1` — the gate was reporting an unfunded workflow as high risk.

The guard is now `budget_usd > 0 and is_over_budget()`. Budget exhaustion remains the dispatch-time gate (`budget.pre_dispatch_block` in `node_dispatch`, same predicate, and it covers the zero-budget case); the approval gate is purely risk-driven. A funded workflow that is genuinely over budget before dispatch still gates.

## 3. No-approval workflows now reach a dispatch pass

`hydra plan` adds `dispatch` to `interrupt_before`, so every planned workflow parks at a bare interrupt. A gated workflow leaves it via `/hydra:approve`; a workflow whose planner set `requires_human_approval=False` had no caller for that pass at all, so skill/impersonation tasks never got their `dispatch.deferred_to_host` marking and the phase never left `dispatch`.

**Smaller change chosen: the first `step`, not `plan`.** `hydra plan` is contractually a halt-before-any-squad-executes surface (its docstring and existing tests pin that), and it runs on a `_NullDispatcher`, so running dispatch there would both break that contract and dispatch on an inert dispatcher. `_run_first_step_dispatch_pass` instead runs the identical `sup.invoke(None, config)` that `approve` runs, on the live attended dispatcher, guarded on: bare interrupt pending, no HITL gate open, approval not required, nothing attended-complete yet (first-step bootstrap only), and no pending engineering task. The last guard keeps engineering deferral semantics untouched — that is fix-E2-22's scope, and the attended engineering cursor owns that dispatch.

## Files changed

- `hydra_core/cli.py` — `_next_stub_attended_task`, `_task_precedes`, `_drive_stub_task`, `_run_first_step_dispatch_pass`, plus two small call blocks in `_cmd_attended_step`. No existing code reordered.
- `hydra_core/supervisor.py` — one line in `node_planner`'s approval computation.
- `tests/test_attended_stub_route_e2_32.py` — new.

## Tests

| Suite | Result |
|---|---|
| `tests/test_attended_stub_route_e2_32.py` | 11 passed |
| `-k "stub or attended or approval or plan"` | 67 passed, 1 pre-existing failure |
| full `pytest -q` | 1688 passed, 4 skipped, 2 pre-existing failures |

The 2 failures are worktree-environment only (`test_native_pack_dispatch.py::test_active_source_packs_are_host_attended_native_plugins` and `test_claude_native_configuration.py::test_operator_skills_use_canonical_namespace_without_project_duplicates`): the MarketBliss pack symlinks are absent in this worktree. Both fail identically on the parent commit.

Five of the eleven new cases fail on the parent commit and pass here, covering each defect: stub-only workflow, mixed `[stub, executive]` ordering, in-graph record reuse, the first-step dispatch pass, and budget 0 vs 0.1 approval determinism.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
