### PR TITLE
E2-34: DEV_TASK normalization + envelope-rejection surfacing

### DIFF
--- a/hydra_core/cli.py
+++ b/hydra_core/cli.py
@@ -1412,7 +1412,7 @@ def _cmd_ingest_locked(args, project: Path, wf: str, envelopes: list[dict]) -> i
     # and (b) leaves open_pp_runs durable up to the prior item. The in-flight
     # item is at-most-once; its pp run, if started, is finalize-aborted by the
     # drive loop's own exception handler or drained by `hydra reap`.
-    from .ingest import IngestItemResult, release_ingested_ids
+    from .ingest import IngestItemResult, normalize_for_ingest, release_ingested_ids
     # Only un-claim a status that PROVABLY never reached execute_squad, so a
     # corrected re-submit with the same id is not suppressed. `unknown_target`
     # qualifies (routing rejected it before any squad call). `failed` does NOT —
@@ -1425,6 +1425,10 @@ def _cmd_ingest_locked(args, project: Path, wf: str, envelopes: list[dict]) -> i
     agg_items: list = []
     over_budget = False
     for env_dict in envelopes:
+        # E2-34: normalize first so a missing or non-UUID pack id becomes a real
+        # UUID before it is used as the ledger key — otherwise such an envelope
+        # bypasses `processed` and can dispatch twice.
+        env_dict = normalize_for_ingest(env_dict, _emit_ingest)
         eid = env_dict.get("id")
         eid = str(eid) if eid is not None else None
         if eid and eid in processed:
@@ -1440,8 +1444,15 @@ def _cmd_ingest_locked(args, project: Path, wf: str, envelopes: list[dict]) -> i
         )
         # Un-claim if this envelope never reached a squad (wrong type/parse fail)
         # so it can be re-submitted after correction; otherwise mark it processed.
-        item_status = out_i.items[-1].status if out_i.items else "failed"
-        if eid and item_status in _NOT_DISPATCHED:
+        last_item = out_i.items[-1] if out_i.items else None
+        item_status = last_item.status if last_item is not None else "failed"
+        # E2-34: a SCHEMA-rejected item (structured field errors) provably never
+        # reached execute_squad either — it failed before any pp call — so it is
+        # un-claimed like unknown_target. That is narrower than `failed` at
+        # large, which can be a post-start_run abort and must stay claimed.
+        schema_rejected = bool(last_item is not None and last_item.errors)
+        if eid and (item_status in _NOT_DISPATCHED
+                    or (item_status == "failed" and schema_rejected)):
             release_ingested_ids(project, wf, [eid])
         elif eid:
             processed.add(eid)
@@ -2058,6 +2069,7 @@ def _cmd_attended_submit(args) -> int:
                             claim_ingested_ids,
                             dispatch_ingested_envelopes,
                             load_ingested_ids,
+                            normalize_for_ingest,
                             release_ingested_ids,
                         )
                         packs = discover_squads(project)
@@ -2080,6 +2092,14 @@ def _cmd_attended_submit(args) -> int:
                                      {"envelope_id": None, "type": None,
                                       "errors": bad["errors"]})
                                 continue
+                            # E2-34: normalize BEFORE reading the id. A pack may
+                            # omit `id` or use a non-UUID label; keying dedup on
+                            # the raw value would let such an envelope bypass
+                            # `processed` and dispatch twice.
+                            raw = normalize_for_ingest(
+                                raw,
+                                lambda event, payload: emit(project, wf, event, payload),
+                            )
                             envelope_id = raw.get("id")
                             if envelope_id is not None and str(envelope_id) in processed:
                                 outcomes.append({"envelope_id": str(envelope_id),

--- a/hydra_core/cli.py
+++ b/hydra_core/cli.py
@@ -2064,10 +2064,21 @@ def _cmd_attended_submit(args) -> int:
                         if hasattr(dispatcher, "set_squad_packs"):
                             dispatcher.set_squad_packs(packs)
                         outcomes: list[dict[str, object]] = []
+                        # E2-34: envelopes that never reached a squad because
+                        # they failed schema validation. A non-empty list flips
+                        # the top-level status to "envelopes_rejected" so the
+                        # delegation is never dropped inside a "complete".
+                        rejected: list[dict[str, object]] = []
                         processed = load_ingested_ids(project, wf)
                         for raw in emitted:
                             if not isinstance(raw, dict):
-                                outcomes.append({"status": "failed", "detail": "non-object envelope"})
+                                bad = {"status": "failed", "detail": "non-object envelope",
+                                       "errors": [{"field": "", "msg": "non-object envelope"}]}
+                                outcomes.append(bad)
+                                rejected.append(bad)
+                                emit(project, wf, "ingest.invalid_envelope",
+                                     {"envelope_id": None, "type": None,
+                                      "errors": bad["errors"]})
                                 continue
                             envelope_id = raw.get("id")
                             if envelope_id is not None and str(envelope_id) in processed:
@@ -2083,7 +2094,12 @@ def _cmd_attended_submit(args) -> int:
                             )
                             item = outcome.items[-1] if outcome.items else None
                             if envelope_id is not None and item is not None:
-                                if item.status == "unknown_target":
+                                # A schema-rejected envelope never reached a
+                                # squad, so un-claim it: the host can re-submit
+                                # a corrected envelope under the same id without
+                                # being suppressed as a duplicate (E2-34).
+                                if (item.status == "unknown_target"
+                                        or (item.status == "failed" and item.errors)):
                                     release_ingested_ids(project, wf, [str(envelope_id)])
                                 else:
                                     processed.add(str(envelope_id))
@@ -2097,8 +2113,22 @@ def _cmd_attended_submit(args) -> int:
                             except Exception as exc:  # noqa: BLE001
                                 emit(project, wf, "attended.emitted_persist_failed",
                                      {"error": str(exc)})
-                            outcomes.extend(vars(item) for item in outcome.items)
+                            outcomes.extend(vars(it) for it in outcome.items)
+                            rejected.extend(vars(it) for it in outcome.rejected)
                         res["ingest"] = outcomes
+                        if rejected:
+                            # The engineering task itself stays attended-complete
+                            # (it is already in attended_done_task_ids); what is
+                            # NOT complete is the delegation it emitted. Surface
+                            # that as the top-level status and park it on the
+                            # cursor so `step`/finalize can render it.
+                            res["status"] = "envelopes_rejected"
+                            res["rejected_envelopes"] = rejected
+                            host_bridge.record_rejected_envelopes(cfile, rejected)
+                            emit(project, wf, "attended.envelopes_rejected", {
+                                "run_id": str(args.run_id),
+                                "rejected_count": len(rejected),
+                            })
 
         emit(project, wf, "attended.submit", {"run_id": str(args.run_id),
                                               "call_key": str(args.call_key),

--- a/hydra_core/host_bridge.py
+++ b/hydra_core/host_bridge.py
@@ -1466,6 +1466,13 @@ def _step_result(cursor: dict[str, Any], cursor_file: str | Path) -> dict[str, A
         if cursor.get("emitted_envelopes"):
             res["emitted_envelopes"] = cursor["emitted_envelopes"]
             res["emitted_envelope_count"] = len(cursor["emitted_envelopes"])
+        # E2-34: an emitted envelope that failed schema validation is
+        # outstanding work, not a completed stage. Report it on every read of
+        # a terminal cursor and override the reported status so the host
+        # cannot mistake the run for fully complete.
+        if cursor.get("rejected_envelopes"):
+            res["rejected_envelopes"] = cursor["rejected_envelopes"]
+            res["status"] = "envelopes_rejected"
         if cursor.get("artifact_text"):
             res["artifact_text"] = cursor["artifact_text"]
     return res
@@ -2830,6 +2837,31 @@ def mark_charged(cursor_file: str | Path) -> None:
         if cursor.get("state") in _TERMINAL:
             cursor["charged"] = True
             save_cursor(cursor_file, cursor)
+    except Exception:  # noqa: BLE001 — never crash the caller on persist failure
+        pass
+
+
+def record_rejected_envelopes(cursor_file: str | Path,
+                              rejected: list[dict[str, Any]]) -> None:
+    """E2-34: park schema-rejected emitted envelopes on the terminal cursor.
+
+    The engineering task itself completed; what failed is the delegation it
+    emitted. Persisting the rejections here (rather than only returning them
+    once) means a later ``step`` / finalize read still sees the outstanding
+    work, so a dropped DEV_TASK cannot disappear between calls. Fail-soft: a
+    storage hiccup never blocks the calling workflow.
+    """
+    if not rejected:
+        return
+    try:
+        cursor = load_cursor(cursor_file)
+        cursor["rejected_envelopes"] = list(rejected)
+        save_cursor(cursor_file, cursor)
+        _trace(cursor, "attended.envelopes_rejected", {
+            "task_id": cursor.get("task_id"),
+            "squad_slug": cursor.get("squad_slug"),
+            "rejected_count": len(rejected),
+        })
     except Exception:  # noqa: BLE001 — never crash the caller on persist failure
         pass
 

--- a/hydra_core/ingest.py
+++ b/hydra_core/ingest.py
@@ -36,6 +36,7 @@ the highest risk. We defend with two layers:
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Iterable
@@ -72,6 +73,212 @@ def _redact_envelope_dict(env_dict: dict) -> dict:
     return redacted
 
 
+# ---------------------------------------------------------------------------
+# E2-34: pack-envelope normalization
+# ---------------------------------------------------------------------------
+# A claude-skill pack (e.g. RLM-Gaming's Director) hand-writes a DEV_TASK from
+# the prose contract, not from ``hydra_core.schemas.DevTask``. It emitted
+# {type, origin_squad, target_squad, workflow_id, repo, pp_team, title,
+# instructions, acceptance_criteria, budget_usd} — missing the REQUIRED
+# ``owner`` and ``branch``, so validation failed and the delegation was dropped
+# inside a top-level "complete" result (finding E2-34). We now fill safe
+# defaults before validation and fold pack-only keys into real schema fields so
+# nothing is silently lost.
+
+#: The ``DevTask.owner`` literal set, in tie-break priority order.
+DEV_TASK_OWNERS: tuple[str, ...] = ("frontend", "backend", "devops", "data", "fullstack")
+
+#: Keyword -> owner inference table. Matched case-insensitively on word
+#: boundaries against ``pp_team`` (weighted x2 — the most explicit signal),
+#: ``title``, and ``instructions``. Highest score wins; ties break in
+#: ``DEV_TASK_OWNERS`` order; no hit at all falls back to ``"fullstack"``.
+OWNER_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "frontend": ("ui", "ux", "html", "css", "frontend", "front-end", "react",
+                 "component", "stylesheet", "layout", "design-system", "widget"),
+    "backend": ("api", "db", "database", "backend", "back-end", "server",
+                "endpoint", "handler", "service", "sql", "rpc"),
+    "devops": ("deploy", "deployment", "ci", "cd", "pipeline", "docker",
+               "kubernetes", "infra", "infrastructure", "release", "runbook"),
+    "data": ("data", "etl", "elt", "dataset", "warehouse", "analytics",
+             "telemetry", "ingestion"),
+}
+
+_WORD_SPLIT_RE = re.compile(r"[^a-z0-9]+")
+_SLUG_STRIP_RE = re.compile(r"^-+|-+$")
+
+
+def _tokens(text: str) -> list[str]:
+    return [t for t in _WORD_SPLIT_RE.split(str(text).lower()) if t]
+
+
+def infer_dev_task_owner(pp_team: str | None, title: str | None,
+                         instructions: str | None) -> str:
+    """Infer a ``DevTask.owner`` literal from the pack's free-text fields.
+
+    Deterministic: score each owner by keyword hits (``pp_team`` counts double),
+    take the highest score, break ties in ``DEV_TASK_OWNERS`` order, and fall
+    back to ``"fullstack"`` when nothing matches.
+    """
+    scores: dict[str, int] = {owner: 0 for owner in OWNER_KEYWORDS}
+    for text, weight in ((pp_team, 2), (title, 1), (instructions, 1)):
+        if not text:
+            continue
+        toks = set(_tokens(text))
+        # Hyphenated keywords ("front-end") are also compared against the raw
+        # lowercased text, since tokenizing splits them apart.
+        raw = str(text).lower()
+        for owner, words in OWNER_KEYWORDS.items():
+            for word in words:
+                if (word in toks) or ("-" in word and word in raw):
+                    scores[owner] += weight
+    best = max(scores.values())
+    if best == 0:
+        return "fullstack"
+    for owner in DEV_TASK_OWNERS:
+        if scores.get(owner) == best:
+            return owner
+    return "fullstack"  # pragma: no cover — unreachable; best came from scores
+
+
+def slugify(text: str, *, max_words: int = 6, max_len: int = 48) -> str:
+    """Lowercase hyphen-joined slug of at most ``max_words`` words."""
+    words = _tokens(text)[:max_words]
+    return _SLUG_STRIP_RE.sub("", "-".join(words)[:max_len])
+
+
+def default_dev_task_branch(workflow_id: Any, title: str | None,
+                            instructions: str | None) -> str:
+    """``hydra/<workflow-short8>/<slug>`` — the branch a pack omitted."""
+    wf_short = str(workflow_id or "unknown").replace("-", "")[:8] or "unknown"
+    slug = slugify(title or "") or slugify(instructions or "") or "dev-task"
+    return f"hydra/{wf_short}/{slug}"
+
+
+#: Keys packs commonly emit that are NOT ``DevTask`` fields. Pydantic ignores
+#: extras, so without this they would vanish. Each is folded into a real field.
+_DEV_TASK_PACK_ONLY_KEYS: tuple[str, ...] = ("title", "acceptance_criteria", "budget_usd")
+
+
+def normalize_pack_envelope(env: dict) -> dict:
+    """Fill safe defaults on a pack-emitted envelope before schema validation.
+
+    Normalizes ``DEV_TASK`` (the type packs hand-write most often); any other
+    type comes back as an unchanged shallow copy. The returned dict carries
+    ``_normalized_fields`` — the list of fields defaulted or folded — which the
+    caller emits as ``ingest.envelope_normalized``. Pydantic treats that key as
+    an extra and drops it at validation.
+
+    Never raises: a shape this cannot repair falls through to validation, which
+    then reports the real error.
+    """
+    if not isinstance(env, dict):
+        return env
+    out = dict(env)
+    if out.get("type") != "DEV_TASK":
+        return out
+
+    defaulted: list[str] = []
+
+    title = out.get("title") if isinstance(out.get("title"), str) else None
+    instructions = out.get("instructions") if isinstance(out.get("instructions"), str) else None
+    pp_team = out.get("pp_team") if isinstance(out.get("pp_team"), str) else None
+
+    # --- owner -------------------------------------------------------------
+    if not out.get("owner"):
+        out["owner"] = infer_dev_task_owner(pp_team, title, instructions)
+        defaulted.append("owner")
+
+    # --- branch ------------------------------------------------------------
+    if not out.get("branch"):
+        out["branch"] = default_dev_task_branch(out.get("workflow_id"), title, instructions)
+        defaulted.append("branch")
+
+    # --- repo / target_repo_id ---------------------------------------------
+    repo = out.get("repo")
+    if isinstance(repo, str) and repo and not out.get("target_repo_id"):
+        try:
+            from .repo_registry import is_known_repo
+            if is_known_repo(repo):
+                out["target_repo_id"] = repo
+                defaulted.append("target_repo_id")
+        except Exception:  # noqa: BLE001 — registry trouble must not block ingest
+            pass
+    if not out.get("repo"):
+        # ``repo`` is required by the schema; fall back to the resolved repo id
+        # so a pack that only set target_repo_id still validates.
+        out["repo"] = str(out.get("target_repo_id") or ".")
+        defaulted.append("repo")
+
+    # --- fold pack-only keys into real fields so nothing is lost ------------
+    tail_lines: list[str] = []
+
+    acceptance = out.pop("acceptance_criteria", None)
+    if acceptance:
+        items = acceptance if isinstance(acceptance, list) else [acceptance]
+        existing = list(out.get("test_plan") or [])
+        for item in items:
+            text = str(item).strip()
+            if text and text not in existing:
+                existing.append(text)
+        out["test_plan"] = existing
+        defaulted.append("test_plan<-acceptance_criteria")
+
+    budget = out.pop("budget_usd", None)
+    if budget is not None:
+        constraints = dict(out.get("constraints") or {})
+        folded = False
+        if constraints.get("budget_usd") is None:
+            try:
+                constraints["budget_usd"] = float(budget)
+                out["constraints"] = constraints
+                defaulted.append("constraints.budget_usd<-budget_usd")
+                folded = True
+            except (TypeError, ValueError):
+                folded = False
+        if not folded:
+            tail_lines.append(f"budget_usd: {budget}")
+    if title:
+        out.pop("title", None)
+        tail_lines.insert(0, f"Title: {title}")
+
+    # Any remaining key that is neither a DevTask field nor an internal ingest
+    # marker is appended verbatim so the receiving squad still sees it.
+    from .schemas import DevTask as _DevTask
+    known = set(_DevTask.model_fields)
+    for key in sorted(k for k in list(out) if k not in known
+                      and not k.startswith("_") and k not in _DEV_TASK_PACK_ONLY_KEYS):
+        tail_lines.append(f"{key}: {out.pop(key)!r}")
+
+    if tail_lines:
+        tail = "\n".join(tail_lines)
+        base = out.get("instructions")
+        out["instructions"] = (
+            f"{base}\n\n[from originating pack]\n{tail}"
+            if isinstance(base, str) and base
+            else f"[from originating pack]\n{tail}"
+        )
+        defaulted.append("instructions<-pack_only_keys")
+
+    if defaulted:
+        out["_normalized_fields"] = defaulted
+    return out
+
+
+def validation_error_details(exc: Exception) -> list[dict[str, Any]]:
+    """Render a pydantic ValidationError as a JSON-safe field/message list."""
+    errors = getattr(exc, "errors", None)
+    if callable(errors):
+        try:
+            return [
+                {"field": ".".join(str(p) for p in e.get("loc", ())),
+                 "msg": str(e.get("msg", ""))}
+                for e in errors()
+            ]
+        except Exception:  # noqa: BLE001
+            pass
+    return [{"field": "", "msg": str(exc)}]
+
+
 @dataclass
 class IngestItemResult:
     envelope_id: str
@@ -80,6 +287,9 @@ class IngestItemResult:
     status: str          # done | failed | surfaced | running | skipped_duplicate | deferred_to_host | unknown_target
     run_id: str | None = None
     detail: str = ""
+    # E2-34: structured pydantic errors for a `failed` validation item, so the
+    # host sees WHICH fields were wrong instead of one flattened string.
+    errors: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass
@@ -106,6 +316,15 @@ class IngestOutcome:
             it.envelope_id for it in self.items
             if it.status not in ("skipped_duplicate", "unknown_target")
         ]
+
+    @property
+    def rejected(self) -> list[IngestItemResult]:
+        """Items that never reached a squad because they failed validation.
+
+        E2-34: the attended submit path turns a non-empty list into a top-level
+        ``status="envelopes_rejected"`` instead of reporting ``complete`` with
+        the failure buried in the ``ingest`` detail."""
+        return [it for it in self.items if it.status == "failed" and it.errors]
 
     def summary(self) -> dict[str, Any]:
         return {
@@ -162,15 +381,37 @@ def dispatch_ingested_envelopes(
 
     for raw in raw_envelopes:
         # Normalise to a typed envelope (validate raw dicts; pass through
-        # already-typed envelopes).
+        # already-typed envelopes). E2-34: a hand-written pack envelope first
+        # goes through normalize_pack_envelope, which supplies the required
+        # fields the prose contract never documented (owner/branch) and folds
+        # pack-only keys into real schema fields.
+        normalized = raw
+        if isinstance(raw, dict):
+            normalized = normalize_pack_envelope(dict(raw))
+            fields_defaulted = normalized.pop("_normalized_fields", None)
+            if fields_defaulted:
+                _emit("ingest.envelope_normalized", {
+                    "envelope_id": str(normalized.get("id", "?")),
+                    "type": normalized.get("type"),
+                    "fields_defaulted": list(fields_defaulted),
+                })
         try:
-            env = raw if isinstance(raw, HydraEnvelope) else validate_envelope(dict(raw))
+            env = (normalized if isinstance(normalized, HydraEnvelope)
+                   else validate_envelope(dict(normalized)))
         except Exception as exc:  # noqa: BLE001 — bad envelope is an item failure, not a crash
+            bad = normalized if isinstance(normalized, dict) else {}
+            errors = validation_error_details(exc)
             outcome.items.append(IngestItemResult(
-                envelope_id=str((raw or {}).get("id", "?")) if isinstance(raw, dict) else "?",
-                envelope_type=(raw or {}).get("type") if isinstance(raw, dict) else None,
+                envelope_id=str(bad.get("id", "?")),
+                envelope_type=bad.get("type"),
                 target=None, status="failed", detail=f"invalid envelope: {exc}",
+                errors=errors,
             ))
+            _emit("ingest.invalid_envelope", {
+                "envelope_id": str(bad.get("id", "?")),
+                "type": bad.get("type"),
+                "errors": errors,
+            })
             continue
 
         eid = str(env.id)
@@ -220,10 +461,15 @@ def dispatch_ingested_envelopes(
             safe_dict = _redact_envelope_dict(env.model_dump(mode="json"))
             safe_env = validate_envelope(safe_dict)
         except Exception as exc:  # noqa: BLE001
+            errors = validation_error_details(exc)
             outcome.items.append(IngestItemResult(
                 envelope_id=eid, envelope_type=etype, target=target,
                 status="failed", detail=f"redaction/validation failed: {exc}",
+                errors=errors,
             ))
+            _emit("ingest.invalid_envelope", {
+                "envelope_id": eid, "type": etype, "errors": errors,
+            })
             continue
 
         task = TaskState(

--- a/hydra_core/ingest.py
+++ b/hydra_core/ingest.py
@@ -40,6 +40,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Iterable
+from uuid import UUID, uuid4
 
 from .governance import charge_and_gate, redact_for_squad_boundary
 from .schemas import HydraEnvelope, validate_envelope
@@ -159,14 +160,41 @@ def default_dev_task_branch(workflow_id: Any, title: str | None,
 _DEV_TASK_PACK_ONLY_KEYS: tuple[str, ...] = ("title", "acceptance_criteria", "budget_usd")
 
 
+def _normalize_envelope_id(out: dict, defaulted: list[str]) -> None:
+    """Guarantee ``out["id"]`` is a UUID string, preserving a non-UUID original.
+
+    ``HydraEnvelope.id`` is a ``UUID``. A host-run pack labels its envelopes
+    however it likes — the observed case was ``"devtask-hydra-heads-166fc7ee"``,
+    which ``hydra.workflow.submit_envelopes`` accepted and the detached ingest
+    then rejected with "id Input should be a valid UUID", visible only in
+    ``ingest.log``. We mint a UUID4 and keep the original in ``external_id`` so
+    the pack's own reference still resolves.
+
+    A MISSING id is synthesized too: the dedup ledger keys on the id, so an
+    envelope without one would bypass ``processed`` entirely.
+    """
+    raw_id = out.get("id")
+    if raw_id is not None and str(raw_id).strip():
+        try:
+            UUID(str(raw_id))
+            return
+        except (ValueError, AttributeError, TypeError):
+            if not out.get("external_id"):
+                out["external_id"] = str(raw_id)
+                defaulted.append("external_id")
+    out["id"] = str(uuid4())
+    defaulted.append("id")
+
+
 def normalize_pack_envelope(env: dict) -> dict:
     """Fill safe defaults on a pack-emitted envelope before schema validation.
 
-    Normalizes ``DEV_TASK`` (the type packs hand-write most often); any other
-    type comes back as an unchanged shallow copy. The returned dict carries
-    ``_normalized_fields`` — the list of fields defaulted or folded — which the
-    caller emits as ``ingest.envelope_normalized``. Pydantic treats that key as
-    an extra and drops it at validation.
+    ``id`` is normalized for EVERY envelope type (see ``_normalize_envelope_id``);
+    the remaining repairs apply to ``DEV_TASK``, the type packs hand-write most
+    often. The returned dict carries ``_normalized_fields`` — the list of fields
+    defaulted or folded — which the caller emits as
+    ``ingest.envelope_normalized``. Pydantic treats that key as an extra and
+    drops it at validation.
 
     Never raises: a shape this cannot repair falls through to validation, which
     then reports the real error.
@@ -174,10 +202,12 @@ def normalize_pack_envelope(env: dict) -> dict:
     if not isinstance(env, dict):
         return env
     out = dict(env)
-    if out.get("type") != "DEV_TASK":
-        return out
-
     defaulted: list[str] = []
+    _normalize_envelope_id(out, defaulted)
+    if out.get("type") != "DEV_TASK":
+        if defaulted:
+            out["_normalized_fields"] = defaulted
+        return out
 
     title = out.get("title") if isinstance(out.get("title"), str) else None
     instructions = out.get("instructions") if isinstance(out.get("instructions"), str) else None
@@ -261,6 +291,33 @@ def normalize_pack_envelope(env: dict) -> dict:
 
     if defaulted:
         out["_normalized_fields"] = defaulted
+    return out
+
+
+def normalize_for_ingest(env: dict,
+                         emit_fn: Callable[[str, dict], None] | None = None) -> dict:
+    """``normalize_pack_envelope`` + the ``ingest.envelope_normalized`` trace.
+
+    Returns the normalized dict with the ``_normalized_fields`` marker stripped,
+    so callers can hand it straight to ``validate_envelope`` or persist it.
+    Idempotent: normalizing an already-normalized envelope defaults nothing and
+    emits nothing, which is what lets the CLI normalize once for dedup and still
+    pass the dict through ``dispatch_ingested_envelopes``.
+    """
+    if not isinstance(env, dict):
+        return env
+    out = normalize_pack_envelope(env)
+    fields_defaulted = out.pop("_normalized_fields", None)
+    if fields_defaulted and emit_fn is not None:
+        try:
+            emit_fn("ingest.envelope_normalized", {
+                "envelope_id": str(out.get("id", "?")),
+                "external_id": out.get("external_id"),
+                "type": out.get("type"),
+                "fields_defaulted": list(fields_defaulted),
+            })
+        except Exception:  # noqa: BLE001 — tracing must never break ingest
+            pass
     return out
 
 
@@ -385,16 +442,7 @@ def dispatch_ingested_envelopes(
         # goes through normalize_pack_envelope, which supplies the required
         # fields the prose contract never documented (owner/branch) and folds
         # pack-only keys into real schema fields.
-        normalized = raw
-        if isinstance(raw, dict):
-            normalized = normalize_pack_envelope(dict(raw))
-            fields_defaulted = normalized.pop("_normalized_fields", None)
-            if fields_defaulted:
-                _emit("ingest.envelope_normalized", {
-                    "envelope_id": str(normalized.get("id", "?")),
-                    "type": normalized.get("type"),
-                    "fields_defaulted": list(fields_defaulted),
-                })
+        normalized = normalize_for_ingest(raw, _emit) if isinstance(raw, dict) else raw
         try:
             env = (normalized if isinstance(normalized, HydraEnvelope)
                    else validate_envelope(dict(normalized)))

--- a/hydra_core/schemas.py
+++ b/hydra_core/schemas.py
@@ -48,6 +48,12 @@ class Constraints(BaseModel):
 class HydraEnvelope(BaseModel):
     """Base envelope shared by every cross-squad message."""
     id: UUID = Field(default_factory=uuid4)
+    # E2-34: the identifier the ORIGINATING system used, when it was not a
+    # UUID. A host-run pack may label its envelope "devtask-hydra-heads-166fc7ee";
+    # `hydra_core.ingest.normalize_pack_envelope` mints a real UUID for `id` and
+    # preserves the original here so the pack's own reference still resolves and
+    # the trace stays correlatable. None when the pack supplied a valid UUID.
+    external_id: Optional[str] = None
     type: str
     origin_squad: str
     target_squad: Optional[str] = None

--- a/mcp_servers/hydra_control/server.py
+++ b/mcp_servers/hydra_control/server.py
@@ -278,6 +278,57 @@ def _detached_refusal(kind: str) -> dict[str, Any]:
     }
 
 
+def _normalize_and_validate_envelopes(
+    envelopes: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """E2-34: repair + schema-check envelopes BEFORE the detached ingest starts.
+
+    Returns ``(normalized, rejected)``. ``normalized`` carries the defaults
+    ``hydra_core.ingest.normalize_pack_envelope`` supplies (a UUID ``id`` with
+    the pack's original preserved as ``external_id``, an inferred ``owner``, a
+    synthesized ``branch``, ...). ``rejected`` holds one entry per envelope that
+    still fails ``validate_envelope``, with structured per-field errors.
+
+    Fail-OPEN on an import error only: if ``hydra_core`` is not importable in
+    this process the envelopes pass through untouched and the detached child
+    validates them as it did before — degraded, never a hard block.
+    """
+    try:
+        from hydra_core.ingest import (  # noqa: PLC0415
+            normalize_for_ingest,
+            validation_error_details,
+        )
+        from hydra_core.schemas import validate_envelope  # noqa: PLC0415
+    except Exception:  # noqa: BLE001 — hydra_core not on path in some test envs
+        logger.warning("submit_envelopes: hydra_core unavailable; "
+                       "skipping synchronous validation")
+        return list(envelopes), []
+
+    normalized: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+    for index, env in enumerate(envelopes):
+        try:
+            out = normalize_for_ingest(dict(env))
+        except Exception as exc:  # noqa: BLE001 — a repair failure is a rejection
+            rejected.append({"index": index, "envelope_id": None,
+                             "type": (env or {}).get("type"),
+                             "errors": [{"field": "", "msg": str(exc)}]})
+            continue
+        try:
+            validate_envelope(out)
+        except Exception as exc:  # noqa: BLE001
+            rejected.append({
+                "index": index,
+                "envelope_id": str(out.get("id")) if out.get("id") else None,
+                "external_id": out.get("external_id"),
+                "type": out.get("type"),
+                "errors": validation_error_details(exc),
+            })
+            continue
+        normalized.append(out)
+    return normalized, rejected
+
+
 def _launch_resume(workflow_id: str, action: str, option: str | None) -> dict[str, Any]:
     # Detached gate: resume is automation-only. No fleet exemption — a resume
     # call carries no fleet goal string, so fleet detection is not applicable.
@@ -723,8 +774,24 @@ def _tool_handlers() -> dict[str, Any]:
             return {"ok": False, "error": "each envelope must be an object"}
         if len(envelopes) > 100:
             return {"ok": False, "error": "too many envelopes (max 100)"}
+        # E2-34: normalize + validate SYNCHRONOUSLY here. Before this, a
+        # malformed envelope (e.g. id="devtask-hydra-heads-166fc7ee", which is
+        # not a UUID) was accepted with {launched: true} and only rejected
+        # inside the detached child, visible nowhere but .hydra/<wf>/ingest.log.
+        # The batch is all-or-nothing: nothing is launched and nothing is
+        # claimed, so the host corrects and re-submits the whole list.
+        normalized, rejected = _normalize_and_validate_envelopes(envelopes)
+        if rejected:
+            return {
+                "ok": False,
+                "launched": False,
+                "status": "envelopes_rejected",
+                "rejected": rejected,
+                "error": (f"{len(rejected)} of {len(envelopes)} envelope(s) failed "
+                          "validation; nothing was dispatched"),
+            }
         try:
-            return _launch_ingest(workflow_id, envelopes)
+            return _launch_ingest(workflow_id, normalized)
         except Exception as e:  # noqa: BLE001 — surfaced, never silent
             logger.exception("ingest launch failed")
             return {"ok": False, "launched": False, "error": f"launch_failed: {e}"}

--- a/plugins/hydra/agents/hydra-planner.md
+++ b/plugins/hydra/agents/hydra-planner.md
@@ -46,6 +46,51 @@ the task cannot be planned safely.
 4. Set `Constraints` on every envelope: `budget_usd`, `deadline_ts`, `risk_tolerance`, `priority`, `industries`. These propagate downstream.
 5. Sign every envelope with `origin_squad="hydra"` and a fresh `parent_id` pointing at the planning record.
 
+## Required Fields Per Envelope Type
+
+Every envelope carries the base fields `type`, `origin_squad`, and
+`workflow_id` (a UUID). An envelope missing a required field does not validate,
+is not dispatched, and the delegation it carried is rejected — so fill these in
+rather than relying on the ingest normalizer.
+
+| Type | Required beyond the base |
+|---|---|
+| `C_SUITE_DECISION_PACKET` | `origin` (`CEO`\|`CFO`\|`CMO`\|`CTO`\|`CRO`\|`CAIO`\|`BOARDROOM`), `objective` |
+| `PRD` | `source_goal_id` (UUID), `summary` |
+| `ARCH_RFC` | `risk_assessment`, `rollout_plan` |
+| `DEV_TASK` | `owner`, `repo`, `branch`, `instructions` |
+| `CREATIVE_BRIEF` | `campaign_id` (UUID), `objective`, `target_audience` |
+| `SHOT_LIST` | `brief_id` (UUID) |
+| `ASSET_JOB` | `model_type`, `output_bucket` |
+| `HITL_REQUEST` | `reason`, `summary`, `options` |
+| `DECISION_RECORD` | `decision`, `rationale` |
+| `HANDOFF` | `payload_envelope_id` (UUID) |
+
+`DEV_TASK.owner` is a closed literal set: `"frontend"`, `"backend"`,
+`"fullstack"`, `"devops"`, `"data"`. Nothing else validates.
+
+### Minimum DEV_TASK
+
+```json
+{
+  "type": "DEV_TASK",
+  "origin_squad": "hydra",
+  "target_squad": "engineering",
+  "workflow_id": "166fc7ee-0000-4000-8000-000000000000",
+  "owner": "backend",
+  "repo": "RLMplatform",
+  "branch": "hydra/166fc7ee/idempotency-key-support",
+  "instructions": "Honor Idempotency-Key on POST /payments; replay the prior result."
+}
+```
+
+Prefer also setting `test_plan`, `target_repo_id` (an allow-listed repo id;
+`repo` is free text and is never used for path resolution), `pp_team`, and
+`constraints.budget_usd`. `hydra_core.ingest.normalize_pack_envelope` will
+infer a missing `owner` and synthesize a missing `branch`, and it emits
+`ingest.envelope_normalized` naming every field it had to supply — treat that
+event as a defect in your output, not as a feature.
+
 ## Authority Bounds
 
 - You DO NOT call MCP tools directly. You produce envelopes; the supervisor dispatches them.

--- a/plugins/hydra/agents/hydra-planner.md
+++ b/plugins/hydra/agents/hydra-planner.md
@@ -53,6 +53,10 @@ Every envelope carries the base fields `type`, `origin_squad`, and
 is not dispatched, and the delegation it carried is rejected — so fill these in
 rather than relying on the ingest normalizer.
 
+`id` is optional but MUST be a UUID when set. A readable label such as
+`"devtask-hydra-heads-166fc7ee"` is rejected; the normalizer replaces it with a
+UUID and keeps the original in `external_id`.
+
 | Type | Required beyond the base |
 |---|---|
 | `C_SUITE_DECISION_PACKET` | `origin` (`CEO`\|`CFO`\|`CMO`\|`CTO`\|`CRO`\|`CAIO`\|`BOARDROOM`), `objective` |

--- a/plugins/hydra/skills/cross-squad-message/SKILL.md
+++ b/plugins/hydra/skills/cross-squad-message/SKILL.md
@@ -22,6 +22,66 @@ Every artifact that crosses a squad boundary is a Pydantic envelope defined in `
 | `DECISION_RECORD` | synthesizer | decision, rationale, dissenting_opinions, artifacts |
 | `HANDOFF` | supervisor → squad | granted_tools, granted_memory_scopes, payload_envelope_id |
 
+## Required fields per type
+
+Every envelope also requires the base fields `type`, `origin_squad`,
+`workflow_id` (a UUID). `id` and `created_at` default. Anything below marked
+required must be present or `validate_envelope` raises and the envelope is
+rejected — it is **not** dispatched.
+
+| Type | Required beyond the base | Notes |
+|---|---|---|
+| `C_SUITE_DECISION_PACKET` | `origin` (one of `CEO`, `CFO`, `CMO`, `CTO`, `CRO`, `CAIO`, `BOARDROOM`), `objective` | `proposed_tasks` optional but usually the point |
+| `PRD` | `source_goal_id` (UUID), `summary` | `user_stories`, `acceptance_criteria`, `non_functional_requirements` default to `[]` |
+| `ARCH_RFC` | `risk_assessment`, `rollout_plan` | `related_prd` optional; `proposed_changes` defaults to `[]` |
+| `DEV_TASK` | `owner`, `repo`, `branch`, `instructions` | see below |
+| `CREATIVE_BRIEF` | `campaign_id` (UUID), `objective`, `target_audience` | |
+| `SHOT_LIST` | `brief_id` (UUID) | `shots` defaults to `[]` |
+| `ASSET_JOB` | `model_type`, `output_bucket` | |
+| `HITL_REQUEST` | `reason`, `summary`, `options` | `options` must be non-empty to be answerable |
+| `DECISION_RECORD` | `decision`, `rationale` | `dissenting_opinions` are preserved, never dropped |
+| `HANDOFF` | `payload_envelope_id` (UUID) | grants default to empty (no privilege) |
+
+`DEV_TASK.owner` is a closed literal set — no other value validates:
+
+```
+"frontend" | "backend" | "fullstack" | "devops" | "data"
+```
+
+`DEV_TASK.status` is likewise a literal set (`pending`, `in_progress`, `done`,
+`blocked`, `surfaced`) and defaults to `pending`.
+
+### Minimum DEV_TASK
+
+```json
+{
+  "type": "DEV_TASK",
+  "origin_squad": "rlm-gaming",
+  "target_squad": "engineering",
+  "workflow_id": "166fc7ee-0000-4000-8000-000000000000",
+  "owner": "frontend",
+  "repo": "RLMplatform",
+  "branch": "hydra/166fc7ee/pause-menu-overlay",
+  "instructions": "Implement the pause-menu overlay described in the level spec."
+}
+```
+
+Optional but strongly preferred: `test_plan` (list of strings), `files_touched`,
+`target_repo_id` (an allow-listed repo id — the `repo` free-text field is never
+used for path resolution), `pp_team`, `pp_profile`, and
+`constraints.budget_usd`.
+
+**Normalization is a safety net, not the contract.** `hydra_core.ingest.
+normalize_pack_envelope` fills a missing `owner` (inferred from `pp_team` /
+`title` / `instructions` keywords, defaulting to `fullstack`) and a missing
+`branch` (`hydra/<workflow-short8>/<slug>`), maps an allow-listed `repo` onto
+`target_repo_id`, and folds pack-only keys (`title`, `acceptance_criteria`,
+`budget_usd`) into `instructions` / `test_plan` / `constraints`. It emits
+`ingest.envelope_normalized` with the list of fields it had to supply. Emit the
+fields yourself: an inferred owner or branch is a guess, and anything the
+normalizer still cannot repair is rejected with `ingest.invalid_envelope` and a
+top-level `status="envelopes_rejected"`.
+
 ## Rules
 
 1. NEVER serialize a raw blob across a boundary. Use `MemoryRef` handles (`tier`, `key`, `summary`) and let the receiver resolve via the memory MCP server.

--- a/plugins/hydra/skills/cross-squad-message/SKILL.md
+++ b/plugins/hydra/skills/cross-squad-message/SKILL.md
@@ -29,6 +29,15 @@ Every envelope also requires the base fields `type`, `origin_squad`,
 required must be present or `validate_envelope` raises and the envelope is
 rejected — it is **not** dispatched.
 
+**`id` must be a UUID.** Omit it and one is generated. A human-readable label
+such as `"devtask-hydra-heads-166fc7ee"` does not validate; when a pack sends
+one, `normalize_pack_envelope` mints a UUID and preserves the original in the
+optional `external_id` field, so the pack's own reference still resolves. The
+`hydra.workflow.submit_envelopes` verb now runs that repair and the schema check
+synchronously and returns `status="envelopes_rejected"` without launching, so a
+bad envelope is never accepted with `{launched: true}` and rejected later in
+`ingest.log`.
+
 | Type | Required beyond the base | Notes |
 |---|---|---|
 | `C_SUITE_DECISION_PACKET` | `origin` (one of `CEO`, `CFO`, `CMO`, `CTO`, `CRO`, `CAIO`, `BOARDROOM`), `objective` | `proposed_tasks` optional but usually the point |

--- a/tests/test_ingest_normalization.py
+++ b/tests/test_ingest_normalization.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -31,6 +31,7 @@ from hydra_core.ingest import (
     default_dev_task_branch,
     dispatch_ingested_envelopes,
     infer_dev_task_owner,
+    normalize_for_ingest,
     normalize_pack_envelope,
     slugify,
 )
@@ -58,9 +59,9 @@ def _no_git_harvest(monkeypatch):
 
 def _pack_dev_task(workflow_id: str, **over) -> dict:
     """The shape RLM-Gaming's Director actually emitted on workflow 166fc7ee:
-    no ``owner``, no ``branch``, plus three keys DevTask does not define."""
+    no ``id``, no ``owner``, no ``branch``, plus three keys DevTask does not
+    define. Deliberately id-less — injecting a UUID here would mask the gap."""
     d = {
-        "id": str(uuid4()),
         "type": "DEV_TASK",
         "origin_squad": "rlm-gaming",
         "target_squad": "engineering",
@@ -136,7 +137,7 @@ def test_pack_dev_task_normalizes_and_validates() -> None:
     out = normalize_pack_envelope(raw)
 
     fields = out.pop("_normalized_fields")
-    assert "owner" in fields and "branch" in fields
+    assert "owner" in fields and "branch" in fields and "id" in fields
 
     env = validate_envelope(out)
     # Nothing in pp_team/title/instructions matches a keyword — safe default.
@@ -177,12 +178,14 @@ def test_unknown_extra_keys_are_folded_into_instructions() -> None:
     assert "estimated_hours: 12" in env.instructions
 
 
-def test_non_dev_task_envelope_passes_through_unchanged() -> None:
+def test_non_dev_task_envelope_only_gets_its_id_normalized() -> None:
     src = {"type": "PRD", "origin_squad": "hydra", "workflow_id": str(uuid4()),
            "source_goal_id": str(uuid4()), "summary": "s"}
     out = normalize_pack_envelope(src)
-    assert out == src
     assert out is not src
+    assert out.pop("_normalized_fields") == ["id"]
+    assert UUID(str(out.pop("id")))
+    assert out == src          # nothing else touched on a non-DEV_TASK
 
 
 # --------------------------------------------------------------------------- #
@@ -230,7 +233,7 @@ def test_unrepairable_envelope_is_rejected_with_trace_event(packs) -> None:
     )
 
     assert [it.status for it in outcome.items] == ["failed"]
-    assert outcome.rejected and outcome.rejected[0].envelope_id == hopeless["id"]
+    assert outcome.rejected
     assert any(e["field"] == "owner" for e in outcome.rejected[0].errors)
     # Nothing was dispatched.
     assert not disp.calls
@@ -293,3 +296,123 @@ def test_record_rejected_envelopes_is_a_noop_on_empty(tmp_path) -> None:
     before = cursor_file.read_text(encoding="utf-8")
     host_bridge.record_rejected_envelopes(cursor_file, [])
     assert cursor_file.read_text(encoding="utf-8") == before
+
+
+# --------------------------------------------------------------------------- #
+# id normalization (agy review of PR #40)                                     #
+# --------------------------------------------------------------------------- #
+
+def test_missing_id_is_synthesized_as_a_uuid() -> None:
+    out = normalize_pack_envelope(_pack_dev_task(str(uuid4())))
+    assert "id" in out["_normalized_fields"]
+    assert UUID(str(out["id"]))                 # a real UUID, not a label
+    assert out.get("external_id") is None       # nothing to preserve
+
+
+def test_non_uuid_id_is_replaced_and_preserved_as_external_id() -> None:
+    """The exact shape from issue #31: submit_envelopes accepted this id and the
+    detached ingest then died on "id Input should be a valid UUID"."""
+    raw = _pack_dev_task(str(uuid4()), id="devtask-hydra-heads-166fc7ee")
+    out = normalize_pack_envelope(raw)
+
+    assert set(["id", "external_id"]).issubset(out["_normalized_fields"])
+    assert UUID(str(out["id"]))
+    assert out["external_id"] == "devtask-hydra-heads-166fc7ee"
+
+    env = validate_envelope({k: v for k, v in out.items()
+                             if k != "_normalized_fields"})
+    assert str(env.id) == out["id"]
+    assert env.external_id == "devtask-hydra-heads-166fc7ee"
+
+
+def test_valid_uuid_id_is_left_alone() -> None:
+    eid = str(uuid4())
+    out = normalize_pack_envelope(_pack_dev_task(str(uuid4()), id=eid))
+    assert out["id"] == eid
+    assert out.get("external_id") is None
+    assert "id" not in out.get("_normalized_fields", [])
+
+
+def test_explicit_external_id_is_not_overwritten() -> None:
+    out = normalize_pack_envelope(
+        _pack_dev_task(str(uuid4()), id="not-a-uuid", external_id="keep-me"))
+    assert out["external_id"] == "keep-me"
+    assert UUID(str(out["id"]))
+
+
+def test_normalize_for_ingest_strips_marker_and_emits_once() -> None:
+    events: list[tuple[str, dict]] = []
+    once = normalize_for_ingest(_pack_dev_task(str(uuid4()), id="devtask-abc"),
+                                lambda e, p: events.append((e, p)))
+    assert "_normalized_fields" not in once
+    assert [e for (e, _p) in events] == ["ingest.envelope_normalized"]
+    assert events[0][1]["external_id"] == "devtask-abc"
+    assert "id" in events[0][1]["fields_defaulted"]
+
+    # Idempotent: re-normalizing an already-normalized envelope changes nothing
+    # and emits nothing. This is what lets the CLI normalize for dedup and still
+    # hand the dict to dispatch_ingested_envelopes.
+    events.clear()
+    twice = normalize_for_ingest(dict(once), lambda e, p: events.append((e, p)))
+    assert twice == once
+    assert events == []
+
+
+def test_ingest_dedups_id_less_envelopes_by_normalized_id(packs) -> None:
+    """Without id normalization two id-less envelopes both bypass `processed`.
+    After it, the same dict submitted twice carries the same normalized id and
+    the second is skipped."""
+    state = HydraState(root_goal="x")
+    disp = _ScriptedDispatcher(_happy_responses("pass"), drive=True)
+    normalized = normalize_for_ingest(_pack_dev_task(str(state.workflow_id)))
+
+    outcome = dispatch_ingested_envelopes(
+        state, [normalized, dict(normalized)], packs=packs, dispatcher=disp)
+    assert sorted(it.status for it in outcome.items) == ["done", "skipped_duplicate"]
+
+
+# --------------------------------------------------------------------------- #
+# MCP verb-level rejection                                                    #
+# --------------------------------------------------------------------------- #
+
+def test_verb_normalizes_and_validates_before_launching(monkeypatch) -> None:
+    from mcp_servers.hydra_control import server as hydra_server
+
+    launched: list[tuple[str, list]] = []
+    monkeypatch.setattr(hydra_server, "_launch_ingest",
+                        lambda wf, envs: launched.append((wf, envs))
+                        or {"ok": True, "launched": True, "pid": 1})
+
+    wf = "166fc7ee-1111-4222-8333-444455556666"
+    handler = hydra_server._tool_handlers()["hydra.workflow.submit_envelopes"]
+    res = handler({"workflow_id": wf,
+                   "envelopes": [_pack_dev_task(wf, id="devtask-hydra-heads-166fc7ee")]})
+
+    assert res["ok"] is True and res["launched"] is True
+    # The DETACHED child receives the repaired envelope, not the raw one.
+    (_wf, sent), = launched
+    assert UUID(str(sent[0]["id"]))
+    assert sent[0]["external_id"] == "devtask-hydra-heads-166fc7ee"
+    assert sent[0]["owner"] in {"frontend", "backend", "fullstack", "devops", "data"}
+
+
+def test_verb_rejects_unrepairable_envelope_without_launching(monkeypatch) -> None:
+    from mcp_servers.hydra_control import server as hydra_server
+
+    launched: list = []
+    monkeypatch.setattr(hydra_server, "_launch_ingest",
+                        lambda wf, envs: launched.append((wf, envs)) or {"ok": True})
+
+    wf = "166fc7ee-1111-4222-8333-444455556666"
+    handler = hydra_server._tool_handlers()["hydra.workflow.submit_envelopes"]
+    res = handler({"workflow_id": wf,
+                   "envelopes": [_pack_dev_task(wf, owner="wizard")]})
+
+    assert res["ok"] is False
+    assert res["launched"] is False
+    assert res["status"] == "envelopes_rejected"
+    assert any(e["field"] == "owner" for e in res["rejected"][0]["errors"])
+    assert res["rejected"][0]["index"] == 0
+    # Nothing was dispatched — the rejection is returned by the verb itself,
+    # not buried in .hydra/<wf>/ingest.log.
+    assert launched == []

--- a/tests/test_ingest_normalization.py
+++ b/tests/test_ingest_normalization.py
@@ -1,0 +1,295 @@
+"""E2-34 — pack-emitted envelope normalization and rejection surfacing.
+
+A claude-skill pack hand-writes its DEV_TASKs from the prose contract, which
+never documented the REQUIRED ``owner`` / ``branch`` fields. On workflow
+166fc7ee the rlm-gaming leg emitted such a DEV_TASK, ``submit_host_result``
+returned top-level ``status="complete"``, and the engineering delegation was
+dropped inside an embedded ``ingest`` detail with no trace event and no HITL.
+
+These tests pin the two halves of the fix:
+
+  - ``normalize_pack_envelope`` supplies safe defaults (owner inferred, branch
+    synthesized, allow-listed ``repo`` mapped onto ``target_repo_id``) and folds
+    pack-only keys (``title`` / ``acceptance_criteria`` / ``budget_usd``) into
+    real schema fields so nothing is lost, emitting
+    ``ingest.envelope_normalized``.
+  - an envelope normalization cannot repair is REJECTED loudly:
+    ``ingest.invalid_envelope`` on the trace, structured field errors on the
+    item, and a terminal cursor that reports ``envelopes_rejected`` rather than
+    ``complete``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from hydra_core import host_bridge
+from hydra_core.ingest import (
+    default_dev_task_branch,
+    dispatch_ingested_envelopes,
+    infer_dev_task_owner,
+    normalize_pack_envelope,
+    slugify,
+)
+from hydra_core.schemas import validate_envelope
+from hydra_core.squad_loader import discover_squads
+from hydra_core.state import HydraState
+
+from tests.test_hybrid_dispatch_e2e import _ScriptedDispatcher, _happy_responses
+
+HYDRA_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def packs():
+    return discover_squads(HYDRA_ROOT)
+
+
+@pytest.fixture(autouse=True)
+def _no_git_harvest(monkeypatch):
+    monkeypatch.setattr("hydra_core.squad_node.harvest_pp_run_artifacts",
+                        lambda **_k: None)
+    monkeypatch.setattr("hydra_core.squad_node._run_smoke",
+                        lambda *_a, **_k: ("pass", "stub smoke pass"))
+
+
+def _pack_dev_task(workflow_id: str, **over) -> dict:
+    """The shape RLM-Gaming's Director actually emitted on workflow 166fc7ee:
+    no ``owner``, no ``branch``, plus three keys DevTask does not define."""
+    d = {
+        "id": str(uuid4()),
+        "type": "DEV_TASK",
+        "origin_squad": "rlm-gaming",
+        "target_squad": "engineering",
+        "workflow_id": workflow_id,
+        "repo": "hydra",
+        "pp_team": "game-feature-team",
+        "title": "Deterministic fog of war",
+        "instructions": "Implement deterministic fog-of-war reveal in src/sim/fow.ts",
+        "acceptance_criteria": ["reveal is seed-stable", "no per-frame allocation"],
+        "budget_usd": 40,
+    }
+    d.update(over)
+    return d
+
+
+# --------------------------------------------------------------------------- #
+# owner inference                                                             #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("pp_team,title,instructions,expected", [
+    (None, None, "Restyle the pause menu css and html", "frontend"),
+    (None, "Ship the UI overlay", None, "frontend"),
+    (None, None, "Add an api endpoint backed by the db", "backend"),
+    (None, "Backend service handler", None, "backend"),
+    (None, None, "Deploy the build through ci", "devops"),
+    (None, None, "Add a docker image to the release pipeline", "devops"),
+    (None, None, "Rebuild the etl over the analytics dataset", "data"),
+    (None, None, "Make the thing nicer somehow", "fullstack"),
+    (None, None, "", "fullstack"),
+    # pp_team is weighted x2, so it wins over a single opposing body keyword.
+    ("design-system-team", None, "touch the api once", "frontend"),
+])
+def test_owner_inference_table(pp_team, title, instructions, expected) -> None:
+    assert infer_dev_task_owner(pp_team, title, instructions) == expected
+
+
+def test_inferred_owner_is_always_a_schema_literal() -> None:
+    from hydra_core.ingest import DEV_TASK_OWNERS
+    from hydra_core.schemas import DevTask
+
+    literals = DevTask.model_fields["owner"].annotation.__args__
+    assert set(DEV_TASK_OWNERS) == set(literals)
+
+
+# --------------------------------------------------------------------------- #
+# branch + slug                                                               #
+# --------------------------------------------------------------------------- #
+
+def test_default_branch_uses_workflow_short_and_title_slug() -> None:
+    wf = "166fc7ee-1111-4222-8333-444455556666"
+    assert default_dev_task_branch(wf, "Deterministic Fog of War!", None) == \
+        "hydra/166fc7ee/deterministic-fog-of-war"
+
+
+def test_default_branch_falls_back_to_instructions_then_placeholder() -> None:
+    wf = "166fc7ee-1111-4222-8333-444455556666"
+    assert default_dev_task_branch(wf, None, "one two three four five six seven") == \
+        "hydra/166fc7ee/one-two-three-four-five-six"
+    assert default_dev_task_branch(wf, None, None) == "hydra/166fc7ee/dev-task"
+
+
+def test_slugify_caps_words() -> None:
+    assert slugify("a b c d e f g h") == "a-b-c-d-e-f"
+
+
+# --------------------------------------------------------------------------- #
+# normalization                                                               #
+# --------------------------------------------------------------------------- #
+
+def test_pack_dev_task_normalizes_and_validates() -> None:
+    wf = str(uuid4())
+    raw = _pack_dev_task(wf)
+    out = normalize_pack_envelope(raw)
+
+    fields = out.pop("_normalized_fields")
+    assert "owner" in fields and "branch" in fields
+
+    env = validate_envelope(out)
+    # Nothing in pp_team/title/instructions matches a keyword — safe default.
+    assert env.owner == "fullstack"
+    assert env.branch == f"hydra/{wf.replace('-', '')[:8]}/deterministic-fog-of-war"
+    # `repo` names an allow-listed id, so it is mirrored to target_repo_id.
+    assert env.target_repo_id == "hydra"
+    # Nothing the pack sent was lost.
+    assert env.test_plan == ["reveal is seed-stable", "no per-frame allocation"]
+    assert env.constraints.budget_usd == 40.0
+    assert "Deterministic fog of war" in env.instructions
+    # The input dict is not mutated.
+    assert raw["title"] == "Deterministic fog of war"
+
+
+def test_normalization_does_not_override_explicit_fields() -> None:
+    raw = _pack_dev_task(str(uuid4()), owner="devops", branch="feature/mine",
+                         target_repo_id="hydra")
+    out = normalize_pack_envelope(raw)
+    assert out["owner"] == "devops"
+    assert out["branch"] == "feature/mine"
+    assert "owner" not in out.get("_normalized_fields", [])
+
+
+def test_unknown_repo_is_not_mapped_to_target_repo_id() -> None:
+    out = normalize_pack_envelope(
+        _pack_dev_task(str(uuid4()), repo="definitely-not-registered-repo"))
+    assert out.get("target_repo_id") is None
+    assert out["repo"] == "definitely-not-registered-repo"
+
+
+def test_unknown_extra_keys_are_folded_into_instructions() -> None:
+    out = normalize_pack_envelope(
+        _pack_dev_task(str(uuid4()), estimated_hours=12))
+    assert "estimated_hours" not in out
+    assert "estimated_hours: 12" in out["instructions"]
+    env = validate_envelope({k: v for k, v in out.items() if k != "_normalized_fields"})
+    assert "estimated_hours: 12" in env.instructions
+
+
+def test_non_dev_task_envelope_passes_through_unchanged() -> None:
+    src = {"type": "PRD", "origin_squad": "hydra", "workflow_id": str(uuid4()),
+           "source_goal_id": str(uuid4()), "summary": "s"}
+    out = normalize_pack_envelope(src)
+    assert out == src
+    assert out is not src
+
+
+# --------------------------------------------------------------------------- #
+# dispatch: normalized envelope reaches engineering                           #
+# --------------------------------------------------------------------------- #
+
+def test_pack_shaped_dev_task_dispatches_after_normalization(packs) -> None:
+    state = HydraState(root_goal="game build")
+    disp = _ScriptedDispatcher(_happy_responses("pass"), drive=True)
+    events: list[tuple[str, dict]] = []
+
+    outcome = dispatch_ingested_envelopes(
+        state, [_pack_dev_task(str(state.workflow_id))],
+        packs=packs, dispatcher=disp,
+        emit_fn=lambda e, p: events.append((e, p)),
+    )
+
+    assert [it.status for it in outcome.items] == ["done"]
+    assert [t.owner_squad for t in outcome.new_tasks] == ["engineering"]
+    assert not outcome.rejected
+
+    normalized = [p for (e, p) in events if e == "ingest.envelope_normalized"]
+    assert len(normalized) == 1
+    assert "owner" in normalized[0]["fields_defaulted"]
+    assert "branch" in normalized[0]["fields_defaulted"]
+    assert normalized[0]["type"] == "DEV_TASK"
+
+
+# --------------------------------------------------------------------------- #
+# rejection surfacing                                                         #
+# --------------------------------------------------------------------------- #
+
+def test_unrepairable_envelope_is_rejected_with_trace_event(packs) -> None:
+    state = HydraState(root_goal="x")
+    disp = _ScriptedDispatcher(_happy_responses("pass"), drive=True)
+    events: list[tuple[str, dict]] = []
+
+    # An `owner` outside the literal set: normalization never overrides an
+    # explicit value, so this must fail validation loudly, not be dropped.
+    hopeless = _pack_dev_task(str(state.workflow_id), owner="wizard")
+
+    outcome = dispatch_ingested_envelopes(
+        state, [hopeless], packs=packs, dispatcher=disp,
+        emit_fn=lambda e, p: events.append((e, p)),
+    )
+
+    assert [it.status for it in outcome.items] == ["failed"]
+    assert outcome.rejected and outcome.rejected[0].envelope_id == hopeless["id"]
+    assert any(e["field"] == "owner" for e in outcome.rejected[0].errors)
+    # Nothing was dispatched.
+    assert not disp.calls
+    assert not outcome.new_tasks
+
+    invalid = [p for (e, p) in events if e == "ingest.invalid_envelope"]
+    assert len(invalid) == 1
+    assert invalid[0]["type"] == "DEV_TASK"
+    assert any(err["field"] == "owner" for err in invalid[0]["errors"])
+
+
+def test_unknown_envelope_type_is_rejected(packs) -> None:
+    state = HydraState(root_goal="x")
+    disp = _ScriptedDispatcher(_happy_responses("pass"), drive=True)
+    events: list[tuple[str, dict]] = []
+
+    outcome = dispatch_ingested_envelopes(
+        state, [{"id": str(uuid4()), "type": "NOT_A_TYPE"}],
+        packs=packs, dispatcher=disp,
+        emit_fn=lambda e, p: events.append((e, p)),
+    )
+    assert [it.status for it in outcome.items] == ["failed"]
+    assert outcome.rejected
+    assert any(e == "ingest.invalid_envelope" for (e, _p) in events)
+
+
+def test_terminal_cursor_with_rejections_reports_envelopes_rejected(tmp_path) -> None:
+    """The cursor half of the CLI surfacing: a stage that completed but whose
+    emitted envelope was rejected must NOT read back as `complete`."""
+    cursor_file = tmp_path / "cursor.json"
+    cursor = {
+        "schema": host_bridge.CURSOR_SCHEMA,
+        "workflow_id": str(uuid4()),
+        "run_id": "run_T",
+        "state": "complete",
+        "final_status": "complete",
+        "project_path": str(tmp_path),
+        "kind": "squad",
+    }
+    cursor_file.write_text(json.dumps(cursor), encoding="utf-8")
+
+    assert host_bridge._step_result(
+        host_bridge.load_cursor(cursor_file), cursor_file)["status"] == "complete"
+
+    rejected = [{"envelope_id": "e1", "envelope_type": "DEV_TASK",
+                 "status": "failed",
+                 "errors": [{"field": "owner", "msg": "Field required"}]}]
+    host_bridge.record_rejected_envelopes(cursor_file, rejected)
+
+    res = host_bridge._step_result(host_bridge.load_cursor(cursor_file), cursor_file)
+    assert res["status"] == "envelopes_rejected"
+    assert res["final_status"] == "complete"      # the stage itself did finish
+    assert res["rejected_envelopes"] == rejected
+
+
+def test_record_rejected_envelopes_is_a_noop_on_empty(tmp_path) -> None:
+    cursor_file = tmp_path / "cursor.json"
+    cursor_file.write_text(json.dumps({"schema": host_bridge.CURSOR_SCHEMA,
+                                       "state": "complete"}), encoding="utf-8")
+    before = cursor_file.read_text(encoding="utf-8")
+    host_bridge.record_rejected_envelopes(cursor_file, [])
+    assert cursor_file.read_text(encoding="utf-8") == before


### PR DESCRIPTION
## What

Fixes finding E2-34 (S1): a pack-emitted `DEV_TASK` missing the required `owner` / `branch` fields failed ingest validation, yet `submit_host_result` returned top-level `status="complete"` with the failure buried in an embedded `ingest` detail. No trace event, no HITL — the engineering delegation was dropped silently.

## Changes

- **`hydra_core/ingest.py`** — new `normalize_pack_envelope(env)` runs before validation for `DEV_TASK`:
  - infers a missing `owner` from `pp_team` (weighted x2) / `title` / `instructions` keywords, defaulting to `fullstack`;
  - synthesizes a missing `branch` as `hydra/<workflow-short8>/<slug>`;
  - maps an allow-listed `repo` onto `target_repo_id`;
  - folds pack-only keys (`title`, `acceptance_criteria`, `budget_usd`) and any unknown extras into `instructions` / `test_plan` / `constraints` so nothing is lost;
  - emits `ingest.envelope_normalized {fields_defaulted:[...]}`.
- Validation failures emit `ingest.invalid_envelope {type, errors}` with structured per-field errors on `IngestItemResult.errors`, collected by the new `IngestOutcome.rejected`.
- **`hydra_core/cli.py`** — the attended submit path returns top-level `status="envelopes_rejected"` plus `rejected_envelopes` when any emitted envelope fails validation, and un-claims those ids from the ingest ledger so a corrected re-submit is not suppressed as a duplicate. The engineering task itself stays attended-complete.
- **`hydra_core/host_bridge.py`** — `record_rejected_envelopes` parks the rejections on the terminal cursor; `_step_result` reports `envelopes_rejected` on every later read, so the outstanding delegation cannot vanish between calls.
- **Docs** — `plugins/hydra/skills/cross-squad-message/SKILL.md` and `plugins/hydra/agents/hydra-planner.md` now list the required fields for all ten envelope types, the `owner` literal set, and a minimum `DEV_TASK` JSON example. Both state that normalization is a safety net, not the contract.

## Tests

New `tests/test_ingest_normalization.py`, 24 cases: owner-inference table, branch/slug defaults, lossless folding of pack-only keys, dispatch of a pack-shaped `DEV_TASK` through the full engineering loop, and rejection surfacing on both the outcome and the cursor.

| Run | Result |
|---|---|
| `pytest tests -q -k "ingest or envelope or schema or hybrid"` | 91 passed |
| `pytest -q` (full) | 1701 passed, 4 skipped, 2 failed |

The 2 failures are the known worktree-environment ones, both caused by the `marketing-*` symlinks into the MarketBliss checkout not resolving in an isolated worktree: `test_native_pack_dispatch.py::test_active_source_packs_are_host_attended_native_plugins` and `test_claude_native_configuration.py::test_operator_skills_use_canonical_namespace_without_project_duplicates`. Neither touches ingest, schemas, the host bridge, or the CLI.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
