### PR TITLE
E2-36: UTF-8 subprocess decoding everywhere

### DIFF
--- a/hydra_core/dispatcher.py
+++ b/hydra_core/dispatcher.py
@@ -32,6 +32,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from .proc import run_text
+
 logger = logging.getLogger(__name__)
 
 
@@ -456,8 +458,8 @@ class MCPStdioDispatcher:
         if venom_block is not None:
             return venom_block
         try:
-            res = subprocess.run(
-                cmd, env=env, capture_output=True, text=True, timeout=300,
+            res = run_text(
+                cmd, env=env, capture_output=True, timeout=300,
             )
             return {
                 "returncode": res.returncode,

--- a/hydra_core/host_bridge.py
+++ b/hydra_core/host_bridge.py
@@ -42,6 +42,7 @@ from typing import Any, Optional
 import re as _re
 
 from . import telemetry as _telemetry
+from .proc import run_text
 from .squad_node import (
     Dispatcher,
     _augment_with_critique,
@@ -256,8 +257,8 @@ def _baseline_timeout_s() -> int:
 def _git(args: list[str], cwd: str | Path, timeout: int | None = None) -> subprocess.CompletedProcess:
     if timeout is None:
         timeout = _git_timeout_s()
-    return subprocess.run(["git", *args], cwd=str(cwd), capture_output=True,
-                          text=True, timeout=timeout, check=False)
+    return run_text(["git", *args], cwd=str(cwd), capture_output=True,
+                    timeout=timeout, check=False)
 
 
 def _git_repo_root(path: str | Path) -> str | None:
@@ -364,9 +365,9 @@ def _write_worktree_gitexcludes(worktree_path: str) -> None:
     already present in the file are not duplicated.  Fail-soft on any error.
     """
     try:
-        r = subprocess.run(
+        r = run_text(
             ["git", "-C", worktree_path, "rev-parse", "--git-path", "info/exclude"],
-            capture_output=True, text=True, timeout=5, check=False,
+            capture_output=True, timeout=5, check=False,
         )
         if r.returncode != 0 or not r.stdout.strip():
             return
@@ -1347,14 +1348,13 @@ def _capture_baseline_failures(
         if not tests_dir.is_dir():
             continue
         try:
-            res = subprocess.run(
+            res = run_text(
                 [
                     _sys.executable, "-m", "pytest",
                     "tests/", "--no-header", "-q", "--tb=no",
                 ],
                 cwd=cwd,
                 capture_output=True,
-                text=True,
                 check=False,
                 timeout=_baseline_timeout_s(),
             )
@@ -2100,11 +2100,11 @@ def _apply_judge(dispatcher: Dispatcher, cursor: dict[str, Any],
                     else:
                         import sys as _sys
                         try:
-                            _reruns = subprocess.run(
+                            _reruns = run_text(
                                 [_sys.executable, "-m", "pytest",
                                  "tests/", "--no-header", "-q", "--tb=no"],
                                 cwd=work_path,
-                                capture_output=True, text=True, check=False,
+                                capture_output=True, check=False,
                                 timeout=_baseline_timeout_s(),
                             )
                             _current_failing = _parse_failing_tests(

--- a/hydra_core/proc.py
+++ b/hydra_core/proc.py
@@ -1,0 +1,47 @@
+"""UTF-8-safe subprocess helpers (E2-36).
+
+``subprocess.run(..., text=True)`` decodes the child's stdout/stderr with
+``locale.getpreferredencoding()``.  On Windows that is the ANSI codepage
+(cp1252 on a US install), so any byte the codepage cannot map raises
+``UnicodeDecodeError`` inside the reader thread — the thread dies and that
+stream's content is lost silently.  Live evidence: a detached ingest run whose
+codex-CLI stdout contained ``0x90`` killed ``Thread-5 (_readerthread)``.
+
+Every text-mode subprocess call in this repo must therefore pin
+``encoding="utf-8", errors="replace"``.  Use :func:`run_text` for new code;
+``tests/test_no_bare_text_subprocess.py`` fails the build on any bare
+``text=True``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Any
+
+__all__ = ["run_text"]
+
+
+def run_text(cmd: Any, **kwargs: Any) -> "subprocess.CompletedProcess[str]":
+    """``subprocess.run`` in text mode with UTF-8 decoding forced.
+
+    Pins ``text=True, encoding="utf-8", errors="replace"`` so an undecodable
+    byte degrades to U+FFFD instead of killing the reader thread, and merges
+    ``PYTHONIOENCODING=utf-8`` into the child environment so a Python child
+    *encodes* its own output as UTF-8 too.  When ``env`` is not supplied it is
+    derived from ``os.environ`` (equivalent to the inherited environment).
+    """
+    env = kwargs.pop("env", None)
+    child_env = dict(os.environ if env is None else env)
+    child_env["PYTHONIOENCODING"] = "utf-8"
+    kwargs.pop("text", None)
+    kwargs.pop("encoding", None)
+    kwargs.pop("errors", None)
+    return subprocess.run(
+        cmd,
+        env=child_env,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        **kwargs,
+    )

--- a/hydra_core/repo_registry.py
+++ b/hydra_core/repo_registry.py
@@ -138,7 +138,7 @@ def _get_base() -> Path:
             proc = subprocess.run(
                 ["git", "-C", str(repo_dir), "rev-parse", "--git-common-dir"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=5,
                 check=False,
             )
@@ -298,7 +298,7 @@ def resolve_repo_path(repo_id: str) -> Path:
         proc = subprocess.run(
             ["git", "-C", str(candidate), "rev-parse", "--show-toplevel"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
             check=False,
         )
@@ -480,7 +480,8 @@ def register_repo(repo_id: str, path: str, *, force: bool = False,
         if not (target / ".git").exists():
             proc = subprocess.run(
                 ["git", "init", str(target)],
-                capture_output=True, text=True, timeout=30, check=False,
+                capture_output=True, text=True, encoding="utf-8",
+                errors="replace", timeout=30, check=False,
             )
             if proc.returncode != 0:
                 raise ValueError(f"git init failed for {target}: {proc.stderr.strip()}")

--- a/hydra_core/squad_node.py
+++ b/hydra_core/squad_node.py
@@ -33,6 +33,7 @@ from pathlib import Path
 _log = logging.getLogger("hydra.engineering")
 
 from .iolaus import post_dispatch, pre_dispatch
+from .proc import run_text
 from .schemas import (
     DecisionRecord,
     Handoff,
@@ -229,9 +230,9 @@ def _worktree_dirty_set(project_path: str | None) -> set[str]:
     if not (root / ".git").exists() and not (root.parent / ".git").exists():
         return set()
     try:
-        res = subprocess.run(
+        res = run_text(
             ["git", "status", "--porcelain"],
-            cwd=root, capture_output=True, text=True, check=False,
+            cwd=root, capture_output=True, check=False,
         )
     except Exception:  # noqa: BLE001 — never crash on a git hiccup
         return set()
@@ -365,10 +366,9 @@ def _resolve_worktree_main_root(project_path: Path) -> "Path | None":
     Fail-soft: any exception → ``None``. Callers treat None as "not a worktree".
     """
     try:
-        proc = subprocess.run(
+        proc = run_text(
             ["git", "-C", str(project_path), "rev-parse", "--git-common-dir"],
             capture_output=True,
-            text=True,
             timeout=5,
             check=False,
         )
@@ -668,9 +668,9 @@ def _run_smoke(
     _use_shell = os.name == "nt" and cmd[0].lower() in ("npm", "npx", "yarn", "pnpm")
     _timeout = _smoke_timeout_s()
     try:
-        res = subprocess.run(
+        res = run_text(
             cmd if not _use_shell else " ".join(cmd),
-            cwd=smoke_cwd, capture_output=True, text=True,
+            cwd=smoke_cwd, capture_output=True,
             check=False, timeout=_timeout, shell=_use_shell,
         )
     except subprocess.TimeoutExpired as exc:
@@ -850,8 +850,8 @@ def _run_claude_cli(
     else:
         cmd += ["--permission-mode", "acceptEdits"]
     try:
-        res = subprocess.run(
-            cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout_s,
+        res = run_text(
+            cmd, cwd=cwd, capture_output=True, timeout=timeout_s,
             env=sub_env,
         )
         return _parse_claude_cli_result(res.stdout, res.stderr, res.returncode, mdl)
@@ -1021,9 +1021,9 @@ def _judge_artifact_text(
     budget = max_chars  # bound INTERMEDIATE accumulation, not just the final slice
     # Modified tracked files → a real unified diff.
     try:
-        res = subprocess.run(
+        res = run_text(
             ["git", "-C", project_path, "diff", "--", *changed_paths],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True, timeout=30,
         )
         diff = (res.stdout or "").strip()[:budget]
         if diff:
@@ -1033,10 +1033,10 @@ def _judge_artifact_text(
         pass
     # New/untracked files → include their content (git diff omits them).
     try:
-        u = subprocess.run(
+        u = run_text(
             ["git", "-C", project_path, "ls-files", "--others",
              "--exclude-standard", "--", *changed_paths],
-            capture_output=True, text=True, timeout=15,
+            capture_output=True, timeout=15,
         )
         for rel in (u.stdout or "").splitlines():
             if budget <= 0:
@@ -3113,11 +3113,10 @@ def harvest_pp_run_artifacts(
         return None
 
     def _git(*args: str) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(
+        return run_text(
             ["git", *args],
             cwd=root,
             capture_output=True,
-            text=True,
             check=False,
         )
 

--- a/mcp_servers/hydra_control/server.py
+++ b/mcp_servers/hydra_control/server.py
@@ -299,6 +299,11 @@ def _launch_resume(workflow_id: str, action: str, option: str | None) -> dict[st
 
     env = dict(os.environ)
     env.setdefault("PYTHONPATH", str(_HYDRA_ROOT))
+    # E2-36: force UTF-8 in the detached child so its stdout/stderr (and any
+    # CLI output it relays into the log) never depends on the Windows ANSI
+    # codepage. Without this a non-cp1252 byte kills the reader thread.
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
 
     creationflags = 0
     start_new_session = False
@@ -369,6 +374,11 @@ def _launch_ingest(workflow_id: str, envelopes: list[dict[str, Any]]) -> dict[st
 
     env = dict(os.environ)
     env.setdefault("PYTHONPATH", str(_HYDRA_ROOT))
+    # E2-36: force UTF-8 in the detached child so its stdout/stderr (and any
+    # CLI output it relays into the log) never depends on the Windows ANSI
+    # codepage. Without this a non-cp1252 byte kills the reader thread.
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
 
     creationflags = 0
     start_new_session = False
@@ -444,6 +454,11 @@ def _launch_run(goal: str, *, squad: str | None, budget: float | None,
 
     env = dict(os.environ)
     env.setdefault("PYTHONPATH", str(_HYDRA_ROOT))
+    # E2-36: force UTF-8 in the detached child so its stdout/stderr (and any
+    # CLI output it relays into the log) never depends on the Windows ANSI
+    # codepage. Without this a non-cp1252 byte kills the reader thread.
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
 
     creationflags = 0
     start_new_session = False
@@ -488,6 +503,11 @@ def _run_cli_json(cli_args: list[str], *, timeout_s: int,
     cmd = [sys.executable, "-m", "hydra_core.cli", *cli_args]
     env = dict(os.environ)
     env.setdefault("PYTHONPATH", str(_HYDRA_ROOT))
+    # E2-36: force UTF-8 in the detached child so its stdout/stderr (and any
+    # CLI output it relays into the log) never depends on the Windows ANSI
+    # codepage. Without this a non-cp1252 byte kills the reader thread.
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
     try:
         proc = subprocess.run(  # noqa: S603 — fixed argv, validated tokens
             cmd, cwd=str(_HYDRA_ROOT), env=env,
@@ -498,7 +518,8 @@ def _run_cli_json(cli_args: list[str], *, timeout_s: int,
             # (lseek on fd 0 → NtQueryInformationFile blocks forever). Mirrors
             # _launch_run, which already passes DEVNULL for the same reason.
             stdin=subprocess.DEVNULL,
-            capture_output=True, text=True, timeout=timeout_s,
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=timeout_s,
         )
     except subprocess.TimeoutExpired as exc:
         # MU8b: surface whatever partial output was buffered so callers can

--- a/tests/test_no_bare_text_subprocess.py
+++ b/tests/test_no_bare_text_subprocess.py
@@ -1,0 +1,147 @@
+"""E2-36 — no bare ``text=True`` subprocess call may survive in the codebase.
+
+``subprocess.run(..., text=True)`` without an explicit ``encoding`` decodes the
+child's streams with the platform's preferred encoding.  On Windows that is the
+ANSI codepage (cp1252), and a single unmappable byte raises inside the reader
+thread, killing it and losing that stream entirely.  Live evidence: the
+detached ingest log for workflow ``166fc7ee`` shows
+``UnicodeDecodeError: 'charmap' codec can't decode byte 0x90``.
+
+The guard test walks the AST of every source file under ``hydra_core/`` and
+``mcp_servers/`` and fails on any call that passes ``text=True`` (or
+``universal_newlines=True``) without also passing ``encoding=``.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from hydra_core.proc import run_text
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCANNED_DIRS = ("hydra_core", "mcp_servers")
+
+# This file documents the anti-pattern in prose and would otherwise flag itself.
+_EXEMPT = {Path(__file__).resolve()}
+
+
+def _source_files() -> list[Path]:
+    files: list[Path] = []
+    for rel in _SCANNED_DIRS:
+        root = _REPO_ROOT / rel
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            if path.resolve() in _EXEMPT:
+                continue
+            files.append(path)
+    return files
+
+
+def _offenders_in(path: Path) -> list[str]:
+    """Return ``<file>:<line>`` for every call with text=True but no encoding."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError as exc:  # pragma: no cover — a broken file is its own bug
+        pytest.fail(f"{path}: could not parse: {exc}")
+
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        kwargs = {kw.arg for kw in node.keywords if kw.arg}
+        text_mode = any(
+            kw.arg in ("text", "universal_newlines")
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value is True
+            for kw in node.keywords
+        )
+        if text_mode and "encoding" not in kwargs:
+            hits.append(f"{path.relative_to(_REPO_ROOT)}:{node.lineno}")
+    return hits
+
+
+def test_no_bare_text_true_subprocess_calls() -> None:
+    offenders: list[str] = []
+    for path in _source_files():
+        offenders.extend(_offenders_in(path))
+    assert not offenders, (
+        "text=True without encoding= decodes with the Windows ANSI codepage and "
+        "kills the reader thread on the first unmappable byte (E2-36). Use "
+        "hydra_core.proc.run_text, or pass encoding='utf-8', errors='replace'. "
+        "Offenders:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_scanner_detects_a_planted_offender(tmp_path: Path) -> None:
+    """The guard must actually fail on the pattern it claims to catch."""
+    planted = tmp_path / "planted.py"
+    planted.write_text(
+        "import subprocess\n"
+        "subprocess.run(['x'], capture_output=True, text=True)\n",
+        encoding="utf-8",
+    )
+    tree = ast.parse(planted.read_text(encoding="utf-8"))
+    bare = [
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and any(
+            kw.arg == "text" and getattr(kw.value, "value", None) is True
+            for kw in n.keywords
+        )
+        and "encoding" not in {kw.arg for kw in n.keywords}
+    ]
+    assert bare, "scanner logic would not have caught a bare text=True call"
+
+
+def test_run_text_survives_non_cp1252_bytes() -> None:
+    """A child emitting bytes unmappable in cp1252 must not kill the reader."""
+    res = run_text(
+        [sys.executable, "-c",
+         r"import sys; sys.stdout.buffer.write(b'\xe2\x94\x80\x90ok')"],
+        capture_output=True,
+        timeout=60,
+    )
+    assert res.returncode == 0
+    # \xe2\x94\x80 is U+2500 BOX DRAWINGS LIGHT HORIZONTAL; \x90 is not valid
+    # UTF-8 on its own and must degrade to U+FFFD rather than raise.
+    assert res.stdout.endswith("ok")
+    assert "─" in res.stdout
+    assert "�" in res.stdout
+
+
+def test_run_text_forces_utf8_child_io_encoding() -> None:
+    res = run_text(
+        [sys.executable, "-c", "import os; print(os.environ['PYTHONIOENCODING'])"],
+        capture_output=True,
+        timeout=60,
+    )
+    assert res.returncode == 0
+    assert res.stdout.strip().lower().startswith("utf-8")
+
+
+def test_run_text_preserves_caller_env() -> None:
+    res = run_text(
+        [sys.executable, "-c", "import os; print(os.environ['E2_36_MARKER'])"],
+        capture_output=True,
+        timeout=60,
+        env={**{"E2_36_MARKER": "kept"}, "SYSTEMROOT": _systemroot()},
+    )
+    assert res.returncode == 0
+    assert res.stdout.strip() == "kept"
+
+
+def _systemroot() -> str:
+    import os
+    # Windows python refuses to start without SystemRoot in a scrubbed env.
+    return os.environ.get("SYSTEMROOT", os.environ.get("SystemRoot", ""))
+
+
+def test_run_text_returns_completed_process() -> None:
+    res = run_text([sys.executable, "-c", "pass"], capture_output=True, timeout=60)
+    assert isinstance(res, subprocess.CompletedProcess)


### PR DESCRIPTION
## Problem

`subprocess.run(..., text=True)` with no `encoding` decodes the child's stdout/stderr with `locale.getpreferredencoding()`. On Windows that is the ANSI codepage (cp1252), so a single unmappable byte raises `UnicodeDecodeError` inside `_readerthread` — the thread dies and that stream's content is lost silently.

Live evidence from the issue: the detached ingest log for workflow `166fc7ee` (pp run `run_r4kIwmtZSoaR`) shows `Thread-5 (_readerthread) … UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 4791` on codex CLI stdout.

## Fix

New `hydra_core/proc.py::run_text(cmd, **kwargs)` pins `text=True, encoding="utf-8", errors="replace"` and merges `PYTHONIOENCODING=utf-8` into the child env (derived from `os.environ` when `env` is not passed).

**Call sites routed through `run_text` (13):**

| File | Sites |
|---|---|
| `hydra_core/dispatcher.py` | `spawn_subprocess` |
| `hydra_core/host_bridge.py` | `_git`, git-exclude probe, baseline pytest, rerun pytest |
| `hydra_core/squad_node.py` | git status, git-common-dir probe, smoke runner, claude-CLI runner, git diff, git ls-files, nested `_git` |

**Call sites fixed inline with `encoding="utf-8", errors="replace"` (4):** all three in `hydra_core/repo_registry.py` and the synchronous CLI runner in `mcp_servers/hydra_control/server.py`. These keep `subprocess.run` on purpose — their tests monkeypatch the module's `subprocess` attribute wholesale (`monkeypatch.setattr(_rr, "subprocess", SimpleNamespace(run=...))`), which a helper import would bypass. The decoding fix is identical either way.

**Detached launchers:** `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8` added to the child env in `_launch_run`, `_launch_resume`, and the ingest launcher, so the child *encodes* as UTF-8 too.

## Tests

`tests/test_no_bare_text_subprocess.py` (6 tests):

- AST guard over `hydra_core/` and `mcp_servers/` failing on any call with `text=True` (or `universal_newlines=True`) and no `encoding=`, listing offenders
- a self-check that the scanner logic catches a planted offender
- a real subprocess round-trip: a child writing `b'\xe2\x94\x80\x90ok'` decodes to `─�ok` instead of raising
- `PYTHONIOENCODING` forced in the child, caller `env` preserved, return type is `CompletedProcess`

Counts: new file 6 passed. Full suite `1683 passed, 4 skipped, 2 failed` in 6m00s. Both failures are the pre-existing worktree-environment ones, unrelated to this change: `test_claude_native_configuration.py::test_operator_skills_use_canonical_namespace_without_project_duplicates` (no `.claude/agents` directory in a worktree) and `test_native_pack_dispatch.py::test_active_source_packs_are_host_attended_native_plugins` (MarketBliss symlinks absent in a worktree).

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
