### PR TITLE
E2-35: persist claude-skill squad artifacts

### DIFF
--- a/hydra_core/artifact_store.py
+++ b/hydra_core/artifact_store.py
@@ -24,3 +24,44 @@ def write_native_artifact(slug: str, relative: str, content: str) -> MemoryRef:
     candidate.write_text(content, encoding="utf-8")
     rel = candidate.relative_to(root).as_posix()
     return MemoryRef(tier="episodic", key=f"{spec.plugin}:output:{rel}", summary=rel)
+
+
+_ATTENDED_SUFFIXES = frozenset({".md", ".json", ".txt"})
+
+
+def write_attended_artifact(
+    project_root: Path | str,
+    workflow_id: str,
+    relative: str,
+    content: str,
+) -> MemoryRef:
+    """Generic attended artifact store (E2-35).
+
+    Squads whose pack has no ``NATIVE_PACKS`` entry (customer-support, and
+    every other claude-skill pack Hydra does not own a Claude plugin for)
+    previously had their attended artifact dropped on the floor: the only
+    persist path was :func:`write_native_artifact`, which raises for an
+    unregistered slug. This store is always available -- it writes beneath the
+    per-workflow attended tree Hydra already owns -- so a squad result can
+    never be reported ``complete`` with no durable artifact behind it.
+
+    Layout: ``<project_root>/.hydra/<workflow_id>/attended/artifacts/<relative>``.
+    Escapes and non-text artifacts are rejected exactly as in the native store.
+    """
+    wf = str(workflow_id)
+    if not wf or wf in {".", ".."} or any(c in wf for c in "/\\"):
+        raise ArtifactStoreError(f"invalid workflow id {workflow_id!r}")
+    root = (Path(project_root) / ".hydra" / wf / "attended" / "artifacts").resolve()
+    candidate = (root / relative).resolve()
+    if not candidate.is_relative_to(root):
+        raise ArtifactStoreError("artifact path escapes attended artifact root")
+    if candidate.suffix.lower() not in _ATTENDED_SUFFIXES:
+        raise ArtifactStoreError("attended artifact must be a text artifact")
+    candidate.parent.mkdir(parents=True, exist_ok=True)
+    candidate.write_text(content, encoding="utf-8")
+    rel = candidate.relative_to(root).as_posix()
+    return MemoryRef(
+        tier="episodic",
+        key=f"attended:artifacts:{wf}/{rel}",
+        summary=rel,
+    )

--- a/hydra_core/cli.py
+++ b/hydra_core/cli.py
@@ -1949,7 +1949,10 @@ def _cmd_attended_submit(args) -> int:
         # On terminal: charge budget on the authoritative HydraState ledger and
         # record the task outcome into the checkpoint.
         # Rider (b): skip charge if already_charged=True (idempotency guard).
-        if res.get("status") in ("complete", "surfaced", "aborted"):
+        # E2-35: "complete_unpersisted" is terminal too — the pack agent ran and
+        # spent real money, so it must charge like any other terminal outcome.
+        if res.get("status") in ("complete", "complete_unpersisted",
+                                 "surfaced", "aborted"):
             if res.get("already_charged"):
                 # Idempotent re-submit: cursor was already charged on the first
                 # terminal submit.  Return the cached result without re-billing.
@@ -1978,7 +1981,13 @@ def _cmd_attended_submit(args) -> int:
             # the operator and telemetry.
             squad_slug = str(res.get("squad_slug") or "")
             artifact_text = str(res.get("artifact_text") or "")
-            if squad_slug and artifact_text:
+            # E2-35: host_bridge already persisted non-native squad artifacts
+            # (generic store + claude-skill shim) and recorded the outcome on
+            # the cursor. Only squads it left alone — the native packs — reach
+            # the native output-root writer here.
+            already_handled = (res.get("artifact_ref") is not None
+                               or res.get("artifact_persist_error") is not None)
+            if squad_slug and artifact_text and not already_handled:
                 try:
                     from .artifact_store import write_native_artifact
                     ref = write_native_artifact(

--- a/hydra_core/host_bridge.py
+++ b/hydra_core/host_bridge.py
@@ -51,6 +51,7 @@ from .squad_node import (
     _pp_gate_type,
     _pp_inner,
     _pp_ok,
+    _resolve_skill_shim,
     _rubric_md,
     _run_smoke,
     _worktree_dirty_set,
@@ -61,7 +62,13 @@ from .squad_node import (
 CURSOR_SCHEMA = 1
 
 # Terminal cursor states.
-_TERMINAL = {"complete", "surfaced", "aborted"}
+#
+# E2-35: ``complete_unpersisted`` is a terminal COMPLETE-shaped outcome whose
+# artifact could not be persisted anywhere. It is deliberately NOT spelled
+# "complete" so governance/synthesis cannot mistake an artifact-less squad
+# return for a durable one, and it is terminal so the driver stops rather than
+# re-spawning the pack agent.
+_TERMINAL = {"complete", "complete_unpersisted", "surfaced", "aborted"}
 
 _SQ = "engineering"
 
@@ -1468,6 +1475,13 @@ def _step_result(cursor: dict[str, Any], cursor_file: str | Path) -> dict[str, A
             res["emitted_envelope_count"] = len(cursor["emitted_envelopes"])
         if cursor.get("artifact_text"):
             res["artifact_text"] = cursor["artifact_text"]
+        # E2-35: surface where (or whether) the squad artifact landed so the
+        # CLI does not re-attempt a native persist over a ref that already
+        # exists, and so an operator sees an unpersisted result as such.
+        for key in ("artifact_ref", "artifact_persisted_via",
+                    "artifact_persist_error", "artifact_persist_warning"):
+            if cursor.get(key) is not None:
+                res[key] = cursor[key]
     return res
 
 
@@ -2358,7 +2372,98 @@ def begin_squad_stage(
     return _step_result(cursor, cfile)
 
 
-def _apply_squad_result(cursor: dict[str, Any], result: dict[str, Any]) -> None:
+def _has_native_pack(slug: str) -> bool:
+    """True when the squad owns a registered Claude Code plugin pack."""
+    if not slug:
+        return False
+    try:
+        from .native_packs import native_pack
+        native_pack(slug)
+        return True
+    except Exception:  # noqa: BLE001 — unregistered slug or registry error
+        return False
+
+
+def _persist_attended_squad_artifact(
+    dispatcher: Dispatcher,
+    cursor: dict[str, Any],
+    *,
+    cursor_file: str | Path,
+) -> tuple[dict[str, Any] | None, str | None, list[str]]:
+    """Persist a non-native squad's attended artifact (E2-35).
+
+    The CLI persists native-pack results through the pack's declared output
+    root; a squad with no ``NATIVE_PACKS`` entry (customer-support via the
+    xenia shim, for instance) had NO persist path at all, so its result came
+    back ``complete`` with an ``artifact_persist_error`` and no ``artifact_ref``
+    and its work never reached memory or synthesis.
+
+    Ladder, both best-effort:
+
+    1. the generic attended store (``<project>/.hydra/<wf>/attended/artifacts``),
+       which needs no MCP round-trip and is therefore the reliable leg;
+    2. when the squad has a claude-skill shim, ``<prefix>.output.write`` as
+       well, so the pack's own on-disk store stays in sync.
+
+    Returns ``(artifact_ref | None, via | None, errors)``. The caller downgrades
+    the outcome to ``complete_unpersisted`` only when BOTH legs failed.
+    """
+    text = str(cursor.get("artifact_text") or "")
+    slug = str(cursor.get("squad_slug") or "")
+    wf = str(cursor.get("workflow_id") or "")
+    raw_task = str(cursor.get("task_id") or cursor.get("run_id") or "task")
+    task_id = "".join(c for c in raw_task if c.isalnum() or c in "-_") or "task"
+    errors: list[str] = []
+    via: list[str] = []
+    ref: dict[str, Any] | None = None
+
+    try:
+        from .artifact_store import write_attended_artifact
+        # `cursor["project_path"]` is the PACK cwd for squad cursors, not the
+        # Hydra project root, so derive the root from the cursor sidecar path
+        # (`<project>/.hydra/<wf>/attended/<run>.json`) instead.
+        project_root = Path(cursor_file).resolve().parents[3]
+        mref = write_attended_artifact(project_root, wf, f"{task_id}.md", text)
+        ref = mref.model_dump(mode="json")
+        via.append("generic")
+    except Exception as exc:  # noqa: BLE001 — fail-soft; the shim leg may still land
+        errors.append(f"generic store: {exc}")
+
+    shim = _resolve_skill_shim(slug) if slug else None
+    if shim:
+        tool = f"{shim['prefix']}.output.write"
+        try:
+            args: dict[str, Any] = {
+                shim["path_key"]: "attended",
+                "topic": f"attended {raw_task}"[:80],
+                "content": text,
+            }
+            if shim["server"] == "rlm_creative":
+                args.update({"domain": "creative", "scopes": ["team:garland-crew"]})
+            resp = dispatcher.call_mcp(shim["server"], tool, args, squad_id=slug)
+            _raise_on_error_payload(resp, tool)
+            via.append("shim")
+            rel = resp.get("relative") if isinstance(resp, dict) else None
+            if ref is None and rel:
+                from .schemas import MemoryRef
+                ref = MemoryRef(
+                    tier="episodic",
+                    key=f"{shim['prefix']}:output:{rel}",
+                    summary=str(rel),
+                ).model_dump(mode="json")
+        except Exception as exc:  # noqa: BLE001 — pack store is best-effort
+            errors.append(f"{tool}: {exc}")
+
+    return ref, ("+".join(via) or None), errors
+
+
+def _apply_squad_result(
+    dispatcher: Dispatcher,
+    cursor: dict[str, Any],
+    result: dict[str, Any],
+    *,
+    cursor_file: str | Path,
+) -> None:
     """await_squad_agent → terminal.
 
     Accumulate spend from the host agent's result and mark the cursor complete.
@@ -2378,14 +2483,43 @@ def _apply_squad_result(cursor: dict[str, Any], result: dict[str, Any]) -> None:
     # workflow lock; never silently discard a DEV_TASK or CREATIVE_BRIEF.
     emitted = result.get("emitted_envelopes", result.get("envelopes", []))
     cursor["emitted_envelopes"] = emitted if isinstance(emitted, list) else []
-    cursor["final_status"] = "complete"
-    cursor["state"] = "complete"
+
+    # E2-35: a squad with no native pack still gets its artifact persisted --
+    # generically, and (when it has one) through its claude-skill shim too.
+    # Native packs are left to the CLI's `write_native_artifact` path, which
+    # already returns a `<plugin>:output:...` ref for them.
+    slug = str(cursor.get("squad_slug") or "")
+    final_status = "complete"
+    if cursor["artifact_text"] and not _has_native_pack(slug):
+        ref, via, errors = _persist_attended_squad_artifact(
+            dispatcher, cursor, cursor_file=cursor_file)
+        if ref is not None:
+            cursor["artifact_ref"] = ref
+            cursor["artifact_persisted_via"] = via
+            _trace(cursor, "attended.skill_artifact_persisted", {
+                "squad": slug, "memory_ref": ref.get("key"), "via": via,
+            })
+            if errors:
+                # One leg landed; keep the other's failure visible without
+                # downgrading a result that IS durably persisted.
+                cursor["artifact_persist_warning"] = "; ".join(errors)
+        else:
+            final_status = "complete_unpersisted"
+            cursor["artifact_persist_error"] = (
+                "; ".join(errors) or "no attended artifact persist path succeeded")
+            _trace(cursor, "attended.skill_artifact_persist_failed", {
+                "squad": slug, "error": cursor["artifact_persist_error"],
+            })
+
+    cursor["final_status"] = final_status
+    cursor["state"] = final_status
     cursor["pending_action"] = None
     cursor["finalized"] = True
     _trace(cursor, "attended.squad_result_applied", {
         "task_id": cursor.get("task_id"),
         "squad_slug": cursor.get("squad_slug"),
         "cost_usd": cursor.get("cost_usd"),
+        "final_status": final_status,
         "emitted_envelope_count": len(cursor["emitted_envelopes"]),
     })
 
@@ -2806,7 +2940,7 @@ def submit_host_result(
                      cursor_file=cursor_file, call_key=call_key)
     elif state == "await_squad_agent":
         # Lightweight non-engineering squad flow — no pp protocol calls needed.
-        _apply_squad_result(cursor, result)
+        _apply_squad_result(dispatcher, cursor, result, cursor_file=cursor_file)
     else:  # pragma: no cover — defensive
         cursor["state"] = "aborted"
         cursor["final_status"] = "aborted"

--- a/tests/test_attended_skill_artifact_persist.py
+++ b/tests/test_attended_skill_artifact_persist.py
@@ -1,0 +1,148 @@
+"""E2-35: attended claude-skill squad artifacts are always persisted.
+
+A squad with no ``NATIVE_PACKS`` entry (customer-support via the xenia shim)
+used to come back ``complete`` with ``artifact_persist_error`` and no
+``artifact_ref``, so its output never reached memory or synthesis. These tests
+pin the generic attended store, the best-effort shim leg, and the
+``complete_unpersisted`` downgrade when every persist path fails.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from hydra_core import artifact_store, host_bridge
+
+
+class _StubDispatcher:
+    """Records `<prefix>.output.write` calls; optionally fails them."""
+
+    def __init__(self, *, fail: bool = False, relative: str | None = None) -> None:
+        self.fail = fail
+        self.relative = relative
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def call_mcp(self, server: str, tool: str, args: dict[str, Any],
+                 *, squad_id: str | None = None) -> dict[str, Any]:
+        self.calls.append((server, tool, args))
+        if self.fail:
+            return {"status": "failed", "error": "xenia shim unreachable"}
+        out: dict[str, Any] = {"status": "done"}
+        if self.relative:
+            out["relative"] = self.relative
+        return out
+
+
+def _begin(tmp_path: Path, wf: str, *, slug: str = "customer-support") -> dict[str, Any]:
+    return host_bridge.begin_squad_stage(
+        workflow_id=wf, task_id="task-cs1", squad_slug=slug,
+        entrypoint="claude-skill", lead_agent="xenia:support-lead",
+        pack_cwd=str(tmp_path / "pack"), request_text="triage the ticket",
+        project_root=tmp_path,
+    )
+
+
+def _trace_kinds(tmp_path: Path, wf: str) -> list[str]:
+    """Trace lands under the cursor's project_path (the pack cwd for squads)."""
+    path = tmp_path / "pack" / ".hydra" / wf / "trace.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line)["kind"] for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_skill_squad_artifact_persisted_generically_and_via_shim(tmp_path: Path) -> None:
+    wf = str(uuid4())
+    started = _begin(tmp_path, wf)
+    disp = _StubDispatcher(relative="triage/attended.md")
+
+    res = host_bridge.submit_host_result(
+        disp, cursor_file=started["cursor_path"], call_key="squad-task-cs1-0",
+        result={"text": "# Ticket triage"},
+    )
+
+    assert res["status"] == "complete"
+    assert res["artifact_persisted_via"] == "generic+shim"
+    assert res["artifact_ref"]["tier"] == "episodic"
+    assert res["artifact_ref"]["key"] == f"attended:artifacts:{wf}/task-cs1.md"
+    assert "artifact_persist_error" not in res
+
+    written = tmp_path / ".hydra" / wf / "attended" / "artifacts" / "task-cs1.md"
+    assert written.read_text(encoding="utf-8") == "# Ticket triage"
+
+    # The shim leg went to xenia's output writer with the squad's RBAC id.
+    assert [(s, t) for s, t, _ in disp.calls] == [("xenia", "xenia.output.write")]
+    assert disp.calls[0][2]["content"] == "# Ticket triage"
+    assert "attended.skill_artifact_persisted" in _trace_kinds(tmp_path, wf)
+
+
+def test_shim_failure_still_persists_generically(tmp_path: Path) -> None:
+    wf = str(uuid4())
+    started = _begin(tmp_path, wf)
+    disp = _StubDispatcher(fail=True)
+
+    res = host_bridge.submit_host_result(
+        disp, cursor_file=started["cursor_path"], call_key="squad-task-cs1-0",
+        result={"text": "# Ticket triage"},
+    )
+
+    assert res["status"] == "complete"
+    assert res["artifact_persisted_via"] == "generic"
+    assert res["artifact_ref"]["key"] == f"attended:artifacts:{wf}/task-cs1.md"
+    assert "xenia shim unreachable" in res["artifact_persist_warning"]
+    assert (tmp_path / ".hydra" / wf / "attended" / "artifacts" / "task-cs1.md").exists()
+
+
+def test_all_persist_paths_failing_yields_complete_unpersisted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    wf = str(uuid4())
+    started = _begin(tmp_path, wf)
+
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise OSError("disk is read-only")
+
+    monkeypatch.setattr(artifact_store, "write_attended_artifact", _boom)
+    disp = _StubDispatcher(fail=True)
+
+    res = host_bridge.submit_host_result(
+        disp, cursor_file=started["cursor_path"], call_key="squad-task-cs1-0",
+        result={"text": "# Ticket triage"},
+    )
+
+    assert res["status"] == "complete_unpersisted"
+    assert res["final_status"] == "complete_unpersisted"
+    assert "artifact_ref" not in res
+    assert "disk is read-only" in res["artifact_persist_error"]
+    assert "xenia shim unreachable" in res["artifact_persist_error"]
+    assert "attended.skill_artifact_persist_failed" in _trace_kinds(tmp_path, wf)
+
+
+def test_squad_without_shim_still_persists_generically(tmp_path: Path) -> None:
+    """A claude-skill squad missing a _SKILL_PACK_SHIMS entry must not lose work."""
+    wf = str(uuid4())
+    started = _begin(tmp_path, wf, slug="healthcare")
+    disp = _StubDispatcher()
+
+    res = host_bridge.submit_host_result(
+        disp, cursor_file=started["cursor_path"], call_key="squad-task-cs1-0",
+        result={"text": "# Notes"},
+    )
+
+    assert res["status"] == "complete"
+    assert res["artifact_persisted_via"] == "generic"
+    assert disp.calls == []
+
+
+def test_attended_store_rejects_escape_and_binary(tmp_path: Path) -> None:
+    ref = artifact_store.write_attended_artifact(tmp_path, "wf1", "a/b.md", "hi")
+    assert ref.key == "attended:artifacts:wf1/a/b.md"
+    with pytest.raises(artifact_store.ArtifactStoreError):
+        artifact_store.write_attended_artifact(tmp_path, "wf1", "../../escape.md", "no")
+    with pytest.raises(artifact_store.ArtifactStoreError):
+        artifact_store.write_attended_artifact(tmp_path, "wf1", "asset.png", "no")
+    with pytest.raises(artifact_store.ArtifactStoreError):
+        artifact_store.write_attended_artifact(tmp_path, "../evil", "a.md", "no")


### PR DESCRIPTION
Attended `submit_host_result` persisted squad artifacts only through the native-pack path. A squad with no `NATIVE_PACKS` entry (customer-support via the xenia shim) came back `status="complete"` with `artifact_persist_error: "no native Claude Code pack registered for 'customer-support'"` and no `artifact_ref`, so its output never reached memory or synthesis.

**Change** — `hydra_core/host_bridge.py::_apply_squad_result` now persists non-native squad artifacts itself:

- always to a generic attended store, `<project>/.hydra/<wf>/attended/artifacts/<task_id>.md`, returning `artifact_ref {tier:"episodic", key:"attended:artifacts:<wf>/<task>.md"}` (new `artifact_store.write_attended_artifact`, escape- and text-only-guarded like the native writer);
- additionally, when the squad has a `_SKILL_PACK_SHIMS` entry, through `<prefix>.output.write` (fail-soft) so the pack's own store stays in sync.

Both legs are best-effort; the winning path is recorded as `artifact_persisted_via` (plus `artifact_persist_warning` when only one leg landed) and traced as `attended.skill_artifact_persisted`. When every path fails, the outcome downgrades to the new terminal status `complete_unpersisted` carrying `artifact_persist_error`, so an artifact-less squad return can never masquerade as `complete`.

Native packs are unchanged: the CLI's `write_native_artifact` path still owns them and now skips squads host_bridge already resolved. `cli.py` touches are two guards only (charge on the new terminal status; skip the native writer when a ref or error already exists).

**Tests** — new `tests/test_attended_skill_artifact_persist.py` (5 tests, stub dispatcher): generic + shim persist, shim failure still persisted generically, all paths failing yields `complete_unpersisted`, squad with no shim, and store guard rails.

| run | result |
|---|---|
| `-k "host_bridge or squad or attended or native"` | 195 passed, 2 failed |
| full `pytest -q` | 1682 passed, 4 skipped, 2 failed |

The 2 failures are the known worktree-environment ones (`test_active_source_packs_are_host_attended_native_plugins`, `test_operator_skills_use_canonical_namespace_without_project_duplicates`): the marketing-* squad symlinks and plugin skills do not resolve from a linked worktree. Three further tests skip for the same reason (sibling Senate/RLM-Creative/Xenia checkouts not visible).

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki