### PR TITLE
E2-39: gateway catalog preserves pp tool input schemas

### DIFF
--- a/hydra_core/toolshed.py
+++ b/hydra_core/toolshed.py
@@ -984,6 +984,140 @@ SCHEMA_OVERRIDES: dict[str, dict[str, dict[str, Any]]] = {
             },
         },
     },
+    # E2-39: the cross-vendor judge/generator tools take a REQUIRED `cwd`.
+    # Without a hand-seed the gateway advertised them parameterless whenever
+    # ~/.hydra/gateway_schemas.json was missing or held a placeholder, so hosts
+    # could not discover `cwd` and the first live call failed zod validation.
+    "pp_codex": {
+        "generate": {
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string"},
+                "cwd": {
+                    "type": "string",
+                    "description": "Absolute working directory for the sub-CLI. REQUIRED.",
+                },
+                "model": {"type": "string"},
+                "sandbox": {
+                    "type": "string",
+                    "enum": ["read-only", "workspace-write", "danger-full-access"],
+                },
+                "output_schema": {
+                    "description": "Optional JSON schema the output must conform to.",
+                },
+                "timeout_ms": {"type": "number"},
+            "untrusted_inputs": {
+                "type": "array",
+                "description": (
+                    "Untrusted evidence to fence off from the instruction "
+                    "channel. Each item is {label, text}."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "label": {"type": "string"},
+                        "text": {"type": "string"},
+                    },
+                    "required": ["label", "text"],
+                    "additionalProperties": False,
+                },
+            },
+            "skip_recap": {"type": "boolean"},
+                "reasoning_effort": {
+                    "type": "string",
+                    "enum": ["minimal", "low", "medium", "high", "xhigh"],
+                },
+            },
+            "required": ["prompt", "cwd"],
+            "additionalProperties": False,
+        },
+        "critique": {
+            "type": "object",
+            "properties": {
+            "artifact_text": {
+                "type": "string",
+                "description": "The artifact (diff, spec, code) under review.",
+            },
+            "rubric_md": {
+                "type": "string",
+                "description": "Markdown rubric body the judge scores against.",
+            },
+            "cwd": {
+                "type": "string",
+                "description": "Absolute working directory for the sub-CLI. REQUIRED.",
+            },
+            "model": {"type": "string"},
+            "output_schema": {
+                "description": "Optional JSON schema the verdict must conform to.",
+            },
+            "timeout_ms": {"type": "number"},
+                "escalate": {"type": "boolean"},
+            },
+            "required": ["artifact_text", "rubric_md", "cwd"],
+            "additionalProperties": False,
+        },
+    },
+    "pp_agy": {
+        "generate": {
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string"},
+                "cwd": {
+                    "type": "string",
+                    "description": "Absolute working directory for the sub-CLI. REQUIRED.",
+                },
+                "model": {"type": "string"},
+                "output_schema": {
+                    "description": "Optional JSON schema the output must conform to.",
+                },
+                "timeout_ms": {"type": "number"},
+            "untrusted_inputs": {
+                "type": "array",
+                "description": (
+                    "Untrusted evidence to fence off from the instruction "
+                    "channel. Each item is {label, text}."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "label": {"type": "string"},
+                        "text": {"type": "string"},
+                    },
+                    "required": ["label", "text"],
+                    "additionalProperties": False,
+                },
+            },
+            "skip_recap": {"type": "boolean"},
+                "fresh_session": {"type": "boolean"},
+            },
+            "required": ["prompt", "cwd"],
+            "additionalProperties": False,
+        },
+        "critique": {
+            "type": "object",
+            "properties": {
+            "artifact_text": {
+                "type": "string",
+                "description": "The artifact (diff, spec, code) under review.",
+            },
+            "rubric_md": {
+                "type": "string",
+                "description": "Markdown rubric body the judge scores against.",
+            },
+            "cwd": {
+                "type": "string",
+                "description": "Absolute working directory for the sub-CLI. REQUIRED.",
+            },
+            "model": {"type": "string"},
+            "output_schema": {
+                "description": "Optional JSON schema the verdict must conform to.",
+            },
+            "timeout_ms": {"type": "number"},
+            },
+            "required": ["artifact_text", "rubric_md", "cwd"],
+            "additionalProperties": False,
+        },
+    },
 }
 
 
@@ -1009,8 +1143,10 @@ def build_default_shed(dispatcher: Any = None) -> ToolShed:
                                  schemas=SCHEMA_OVERRIDES.get("hydra_control"))
     shed.register_static_catalog("xenia", XENIA_TOOLS)
     shed.register_static_catalog("senate", SENATE_TOOLS)
-    shed.register_static_catalog("pp_codex", PP_CODEX_TOOLS)
-    shed.register_static_catalog("pp_agy", PP_AGY_TOOLS)
+    shed.register_static_catalog("pp_codex", PP_CODEX_TOOLS,
+                                 schemas=SCHEMA_OVERRIDES.get("pp_codex"))
+    shed.register_static_catalog("pp_agy", PP_AGY_TOOLS,
+                                 schemas=SCHEMA_OVERRIDES.get("pp_agy"))
     shed.register_static_catalog("xenia_kb", XENIA_KB_TOOLS)
     shed.register_static_catalog("xenia_tickets", XENIA_TICKETS_TOOLS)
     # Optional / 3rd-party backends — present in backends.template.json and

--- a/mcp_servers/hydra_gateway/server.py
+++ b/mcp_servers/hydra_gateway/server.py
@@ -543,14 +543,53 @@ def _load_schema_cache(path: Path = GATEWAY_SCHEMA_CACHE) -> dict[str, dict[str,
     }
 
 
+_SCHEMA_SHAPE_KEYS = ("properties", "$ref", "anyOf", "oneOf", "allOf",
+                      "patternProperties")
+
+
+def _schema_is_informative(schema: Any) -> bool:
+    """True when ``schema`` actually declares an argument shape.
+
+    A bare ``{"type": "object"}`` — or the ``{"type":"object","properties":{},
+    "required":null}`` placeholder some backends emit before their tool
+    definitions are wired — carries no parameter information. Treating those
+    as "present" lets a placeholder clobber a real schema, which is how
+    ``pp_codex``/``pp_agy`` ``critique``/``generate`` reached hosts with no
+    discoverable ``cwd`` argument (E2-39).
+    """
+    if not isinstance(schema, dict) or not schema:
+        return False
+    return any(schema.get(key) for key in _SCHEMA_SHAPE_KEYS)
+
+
+def _resolve_tool_schema(cached: Any, seeded: Any) -> dict[str, Any]:
+    """Pick the advertised schema for one tool.
+
+    The backend-published (cached) schema wins whenever it declares real
+    parameters. A placeholder never overwrites an informative hand-seeded
+    schema; when neither declares parameters the cached value is still
+    preferred so genuinely parameterless tools keep their published shape.
+    """
+    if _schema_is_informative(cached):
+        return cached
+    if _schema_is_informative(seeded):
+        return seeded
+    if isinstance(cached, dict) and cached:
+        return cached
+    if isinstance(seeded, dict) and seeded:
+        return seeded
+    return {"type": "object"}
+
+
 def _apply_schema_cache_to_shed(shed: Any,
                                 schema_cache: dict[str, dict[str, Any]]) -> None:
     """Overlay warmed schemas onto the ToolShed catalog entries in place, so
     the progressive-disclosure meta-tools (``gateway.describe`` /
     ``gateway.navigate``) resolve the same real schemas the gateway advertises.
-    Cache wins over hand-seeded ``input_schema``; absent a cache entry the
-    hand-seed (or empty) schema is left untouched. Catalog and ``_by_key``
-    share entry objects, so a single mutation updates both views."""
+    An informative cache entry wins over a hand-seeded ``input_schema``; a
+    placeholder cache entry does not (see ``_resolve_tool_schema``). Catalog
+    and ``_by_key`` share entry objects, so a single mutation updates both
+    views."""
     if not schema_cache:
         return
     for server_name, entries in shed._catalog.items():
@@ -559,8 +598,9 @@ def _apply_schema_cache_to_shed(shed: Any,
             continue
         for entry in entries:
             cached = cached_for_server.get(entry.name)
-            if cached:
-                entry.input_schema = cached
+            if cached is None:
+                continue
+            entry.input_schema = _resolve_tool_schema(cached, entry.input_schema)
 
 
 _COERCE_SENTINEL = object()
@@ -718,6 +758,8 @@ def _build_static_tool_list(
     ``schema_cache`` (real schemas fetched offline by ``refresh_schemas``)
     → ``entry.input_schema`` (hand-seeded ``SCHEMA_OVERRIDES``) →
     ``{"type":"object"}`` (last-resort when a backend was never refreshed).
+    A cache entry that declares no parameters is treated as a placeholder and
+    yields to an informative hand-seed rather than overwriting it (E2-39).
     A bare ``{"type":"object"}`` strips param types and makes nested
     objects / numeric args mangle on the proxy hop, so a real schema here
     is what keeps writes like ``eights.memory.add`` and numeric params like
@@ -736,9 +778,8 @@ def _build_static_tool_list(
             continue
         cached_for_server = schema_cache.get(server_name, {})
         for entry in shed._catalog.get(server_name, []):
-            schema = (cached_for_server.get(entry.name)
-                      or entry.input_schema
-                      or {"type": "object"})
+            schema = _resolve_tool_schema(cached_for_server.get(entry.name),
+                                          entry.input_schema)
             tools.append({
                 "name": f"{server_name}__{entry.name}",
                 "description": f"[{server_name}] {entry.description}",

--- a/tests/test_gateway_catalog_complete.py
+++ b/tests/test_gateway_catalog_complete.py
@@ -71,3 +71,125 @@ def test_pp_harness_allowlist_covers_cached_schema_catalog() -> None:
         "pp_harness tools present in the gateway schema catalog but missing "
         f"from PP_HARNESS_TOOLS: {missing}"
     )
+
+
+# --------------------------------------------------------------------------
+# E2-39: pp_codex / pp_agy input schemas must survive the cataloging pipeline.
+# --------------------------------------------------------------------------
+from mcp_servers.hydra_gateway.server import (  # noqa: E402
+    _apply_schema_cache_to_shed, _build_static_tool_list,
+)
+
+# Stand-in for a live `tools/list` against
+# `node pair-programmer/daemon/dist/index.js mcp-agy`.
+FIXTURE_BACKEND_SCHEMAS: dict[str, dict[str, dict]] = {
+    "pp_agy": {
+        "critique": {
+            "type": "object",
+            "properties": {
+                "artifact_text": {"type": "string"},
+                "rubric_md": {"type": "string"},
+                "cwd": {"type": "string"},
+                "model": {"type": "string"},
+                "output_schema": {},
+                "timeout_ms": {"type": "number"},
+            },
+            "required": ["artifact_text", "rubric_md", "cwd"],
+            "additionalProperties": False,
+        },
+        "generate": {
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string"},
+                "cwd": {"type": "string"},
+            },
+            "required": ["prompt", "cwd"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+# What the schema refresh wrote before the fix: shape without substance.
+PLACEHOLDER_SCHEMA = {"type": "object", "properties": {}, "required": None}
+
+
+def _surfaced(server: str, tool: str, schema_cache: dict) -> dict:
+    """The inputSchema the gateway advertises for one tool."""
+    shed = build_default_shed()
+    _apply_schema_cache_to_shed(shed, schema_cache)
+    specs = {name: {"type": "stdio"} for name in shed.servers}
+    tools = _build_static_tool_list(shed, specs, schema_cache)
+    match = [t for t in tools if t["name"] == f"{server}__{tool}"]
+    assert match, f"{server}__{tool} not advertised by the gateway"
+    return match[0]["inputSchema"]
+
+
+def test_backend_schema_reaches_catalog_describe_and_tool_definition() -> None:
+    """E2-39 parity: a backend-published schema survives every hop.
+
+    The catalogued entry, ``gateway_describe`` and the surfaced tool
+    definition must all carry the backend's ``properties`` and ``required``.
+    """
+    shed = build_default_shed()
+    _apply_schema_cache_to_shed(shed, FIXTURE_BACKEND_SCHEMAS)
+
+    described = shed.describe("pp_agy", "critique")
+    assert described is not None
+    schema = described["input_schema"]
+    assert set(schema["properties"]) >= {"artifact_text", "rubric_md", "cwd"}
+    assert schema["required"] == ["artifact_text", "rubric_md", "cwd"]
+
+    surfaced = _surfaced("pp_agy", "critique", FIXTURE_BACKEND_SCHEMAS)
+    assert surfaced == FIXTURE_BACKEND_SCHEMAS["pp_agy"]["critique"]
+
+
+def test_every_fixture_backend_schema_lands_non_empty() -> None:
+    """Parity sweep: no catalogued tool loses a non-empty backend schema."""
+    shed = build_default_shed()
+    _apply_schema_cache_to_shed(shed, FIXTURE_BACKEND_SCHEMAS)
+
+    for server, tools in FIXTURE_BACKEND_SCHEMAS.items():
+        for tool, backend_schema in tools.items():
+            if not backend_schema.get("properties"):
+                continue
+            described = shed.describe(server, tool)
+            assert described is not None, f"{server}.{tool} missing from catalog"
+            assert described["input_schema"].get("properties"), (
+                f"{server}.{tool} catalogued with an empty schema"
+            )
+
+
+def test_placeholder_cache_entry_never_overwrites_a_real_schema() -> None:
+    """Regression: the empty placeholder must not clobber a real schema.
+
+    ``{"type":"object","properties":{},"required":null}`` is truthy, so the
+    old ``cached or entry.input_schema`` resolution let it win and stripped
+    every parameter from the surfaced tool.
+    """
+    placeholder_cache = {
+        "pp_codex": {"critique": dict(PLACEHOLDER_SCHEMA),
+                     "generate": dict(PLACEHOLDER_SCHEMA)},
+    }
+    shed = build_default_shed()
+    _apply_schema_cache_to_shed(shed, placeholder_cache)
+
+    for tool, required in (("critique", ["artifact_text", "rubric_md", "cwd"]),
+                           ("generate", ["prompt", "cwd"])):
+        described = shed.describe("pp_codex", tool)
+        assert described is not None
+        schema = described["input_schema"]
+        assert schema.get("properties"), f"pp_codex.{tool} stripped by placeholder"
+        assert schema["required"] == required
+
+        surfaced = _surfaced("pp_codex", tool, placeholder_cache)
+        assert "cwd" in surfaced["properties"]
+        assert "cwd" in surfaced["required"]
+
+
+def test_pp_judge_tools_declare_cwd_without_any_schema_cache() -> None:
+    """A fresh checkout (no ~/.hydra cache) still exposes the required args."""
+    for server in ("pp_codex", "pp_agy"):
+        for tool in ("generate", "critique"):
+            surfaced = _surfaced(server, tool, {})
+            assert "cwd" in surfaced.get("properties", {}), f"{server}.{tool}"
+            assert "cwd" in surfaced.get("required", []), f"{server}.{tool}"


### PR DESCRIPTION
## Summary

`mcp__hydra_gateway__pp_codex__critique` / `pp_agy__critique` (and both `generate` tools) surfaced with no parameters, so hosts could not discover the required `cwd` argument. The first live call failed zod validation with `cwd Required`.

## Root cause

Two compounding causes in the cataloging pipeline:

1. `build_default_shed` registers `pp_codex` / `pp_agy` from a bare name list (`PP_CODEX_TOOLS` / `PP_AGY_TOOLS`) with **no** hand-seeded schema, unlike `pp_harness`, `eights`, `hydra_memory` and `hydra_control`. With `~/.hydra/gateway_schemas.json` missing or stale, the catalog entry, `gateway_describe`, and the surfaced tool definition all fell back to `{"type":"object"}` with no properties.
2. Schema resolution used `cached or entry.input_schema` in both `_apply_schema_cache_to_shed` and `_build_static_tool_list`. The placeholder `{"type":"object","properties":{},"required":null}` is truthy, so a parameterless cache entry **overwrote** a real schema rather than yielding to it.

## Fix

- Hand-seed the real `pp_codex` / `pp_agy` `generate` + `critique` schemas in `SCHEMA_OVERRIDES` (matching what the daemon publishes: `critique` requires `artifact_text, rubric_md, cwd`; `generate` requires `prompt, cwd`) and pass them to `register_static_catalog`.
- Route both resolution sites through a new `_resolve_tool_schema`, which prefers whichever source actually declares an argument shape. The backend-published schema still wins whenever it is informative; genuinely parameterless tools keep their published shape.

## Tests

Four new tests in `tests/test_gateway_catalog_complete.py`: a parity test using a fixture backend listing (asserting the catalogued entry, `describe`, and the surfaced tool definition all carry `properties` + `required`), a parity sweep over the fixture, a regression test that a placeholder cache entry never overwrites a real schema, and a no-cache test that `cwd` is still discoverable on a fresh checkout. Two of them fail on the pre-fix code (verified by stashing the source changes).

| Suite | Result |
|---|---|
| `-k "gateway or toolshed or catalog or schema"` | 86 passed |
| full `pytest -q` | 1834 passed, 5 skipped, 2 failed |

The 2 failures (`test_operator_skills_use_canonical_namespace_without_project_duplicates`, `test_active_source_packs_are_host_attended_native_plugins`) are the known worktree-environment failures present on the base commit; they are unrelated to this change.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3cYkyUY47LBwQqoaDBMki
