### PR TITLE
B8: engine-side cost attribution, estimate never block

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -301,6 +301,38 @@ Only `security`/`spec` and `design` differ; `contract -> codex` is identical in
 both systems. This is a considered override — a future reader comparing the two
 repos should not "fix" it.
 
+### 6c-ter. Attended cost provenance (B8) — estimate, never block
+
+An attended host result (the `result` dict a caller hands to
+`submit_host_result`) can omit `cost_usd`. Previously this silently charged the
+stage $0.0 — a CFO tripwire reading a run's real spend as free money.
+`host_bridge._priced_cost` now resolves, per accrual call (generate / judge /
+squad-result):
+
+- **measured** — the host reported `cost_usd` directly (unchanged behaviour).
+- **estimated** — no `cost_usd`, but `tokens_in`/`tokens_out` and a `model` id
+  were reported; `hydra_core/pricing.py::price_call` prices the call from a
+  built-in rate table (overridable at `<HYDRA_HOME>/pricing.json`).
+- **unmeasured** — neither a cost nor a priceable model+tokens; contributes
+  $0.0 and emits an `attended.cost_unmeasured` trace event. This is a log, not
+  a gate: no HITL, no block, and the stage still finalizes normally.
+
+The stage's overall `cost_source` (surfaced in `_step_result` and read by
+`cli.py`'s `charge_and_gate` call) picks the highest-priority source seen
+across the stage's accrual calls — `estimated` > `measured` > `unmeasured`.
+`governance.record_cost(state, usd, tokens, source=...)` folds measured AND
+estimated dollars into `budget.spent_usd` (so the 80%/100% tripwires see
+estimated money too — that is the point) while `budget.estimated_usd` tracks
+only the estimated portion as a companion counter, and `budget.unmeasured_stages`
+counts stages priced at $0.0 for lack of any usable signal.
+
+**Host-side companion:** `hydra_core/transcript_cost.py::summarize_transcript_cost`
+sums a subagent transcript's per-turn `message.usage` (JSONL,
+`input_tokens`/`output_tokens`/`cache_creation_input_tokens`/
+`cache_read_input_tokens` + `message.model`) and prices it through
+`pricing.price_call`, so a host driving the attended loop can report a real
+`cost_usd` instead of relying on the engine's estimate.
+
 **Repo targeting.** The envelope's `target_repo_id` wins when present; otherwise
 `squad_node._via_mcp` falls back to the workflow's already-resolved
 `state.target_repo_id` (allow-list validated at intake in `supervisor.py` via

--- a/hydra_core/cli.py
+++ b/hydra_core/cli.py
@@ -2556,7 +2556,24 @@ def _cmd_recover_stalled_stage(args, project: Path, wf: str, option) -> int:
                 state = HydraState.model_validate(snap.values)
                 cost = float(res.get("cost_usd") or 0.0)
                 toks = int(res.get("tokens_in") or 0) + int(res.get("tokens_out") or 0)
-                block, downgrade = charge_and_gate(state, cost, toks)
+                # B8: host_bridge tags the stage's cost provenance in
+                # "cost_source" ("measured"/"estimated"/"unmeasured") — an
+                # unreporting host no longer charges as free.
+                cost_source = str(res.get("cost_source") or "measured")
+                # Fix (mixed-provenance estimated_usd): "cost_source" is a
+                # single collapsed label for the whole (possibly mixed)
+                # stage, so it cannot be used to size the estimated_usd
+                # credit for a stage that mixed a measured and an estimated
+                # component. Pass the per-component figure host_bridge
+                # tracked separately instead.
+                estimated_component = float(res.get("estimated_cost_usd") or 0.0)
+                block, downgrade = charge_and_gate(
+                    state, cost, toks, source=cost_source,
+                    estimated_usd=estimated_component,
+                )
+                if cost_source == "unmeasured":
+                    emit(project, wf, "attended.cost_unmeasured",
+                         {"stage_id": res.get("stage_id"), "run_id": res.get("run_id")})
                 tid = res.get("task_id")
                 completed = list(state.attended_completed_task_ids)
                 if tid is not None and str(tid) not in completed:
@@ -2691,7 +2708,20 @@ def _cmd_attended_submit(args) -> int:
                     state = HydraState.model_validate(snap.values)
                     cost = float(res.get("cost_usd") or 0.0)
                     toks = int(res.get("tokens_in") or 0) + int(res.get("tokens_out") or 0)
-                    block, downgrade = charge_and_gate(state, cost, toks)
+                    # B8: see the recover-stalled-stage twin above — an
+                    # unreporting host is estimated/unmeasured, never free.
+                    cost_source = str(res.get("cost_source") or "measured")
+                    # Fix (mixed-provenance estimated_usd): see the twin
+                    # comment above — credit only the per-component estimated
+                    # figure, not the whole (possibly mixed) stage total.
+                    estimated_component = float(res.get("estimated_cost_usd") or 0.0)
+                    block, downgrade = charge_and_gate(
+                        state, cost, toks, source=cost_source,
+                        estimated_usd=estimated_component,
+                    )
+                    if cost_source == "unmeasured":
+                        emit(project, wf, "attended.cost_unmeasured",
+                             {"stage_id": res.get("stage_id"), "run_id": res.get("run_id")})
                     # F34: budget_charge to eights (fail-soft; never blocks local work).
                     try:
                         from .eights.attestation import EightsAttestor as _EightsAttestor

--- a/hydra_core/governance.py
+++ b/hydra_core/governance.py
@@ -24,9 +24,46 @@ from .state import HydraState
 
 # --------- budget ---------
 
-def record_cost(state: HydraState, usd: float, tokens: int) -> None:
+def record_cost(
+    state: HydraState,
+    usd: float,
+    tokens: int,
+    source: str = "measured",
+    estimated_usd: float | None = None,
+) -> None:
+    """Charge ``usd``/``tokens`` onto the budget ledger.
+
+    ``source`` is one of ``"measured"`` (a directly reported cost — the
+    default, so every pre-existing caller keeps its current behaviour),
+    ``"estimated"`` (priced via ``hydra_core.pricing`` from tokens+model
+    because the host did not report a cost), or ``"unmeasured"`` (neither a
+    cost nor usable tokens were available; ``usd`` is expected to be 0.0).
+
+    B8: measured AND estimated spend BOTH accumulate into ``spent_usd`` so the
+    0.8/1.0 budget tripwires stay authoritative over estimated money too —
+    that is the point of the estimate. ``estimated_usd`` is a companion
+    counter that additionally tracks only the estimated portion; it never
+    changes what ``spent_usd`` means. ``unmeasured_stages`` counts stages
+    that could not be priced at all.
+
+    Fix (mixed-provenance): ``usd`` may be a stage TOTAL that mixes a
+    measured component with an estimated component (``source`` necessarily
+    collapses to one label for the whole stage — see
+    ``host_bridge._merge_cost_source``). The optional ``estimated_usd``
+    keyword lets a caller pass the exact estimated-only dollar figure it
+    tracked per-component, so this credits ``budget.estimated_usd`` with
+    that precise amount instead of inferring it (wrongly, for a mixed stage)
+    from the collapsed ``source`` label. When omitted, behaviour is
+    unchanged from before this fix.
+    """
     state.budget.spent_usd += usd
     state.budget.spent_tokens += tokens
+    if estimated_usd is not None:
+        state.budget.estimated_usd += estimated_usd
+    elif source == "estimated":
+        state.budget.estimated_usd += usd
+    if source == "unmeasured":
+        state.budget.unmeasured_stages += 1
 
 
 def should_downgrade_model(state: HydraState, threshold: float = 0.8) -> bool:
@@ -43,6 +80,8 @@ def charge_and_gate(
     state: HydraState,
     cost_usd: float,
     cost_tokens: int,
+    source: str = "measured",
+    estimated_usd: float | None = None,
 ) -> tuple[bool, bool]:
     """Record cost then evaluate both budget gates in one call.
 
@@ -53,8 +92,13 @@ def charge_and_gate(
     Callers at every execute_squad site use this so the logic is not
     duplicated across best-of-N, single-shot dispatch, and reflexion.
     Sequential (non-fleet) path only — do NOT replace with charge_and_gate_repo.
+
+    ``source`` (B8) is forwarded to ``record_cost`` unchanged; it defaults to
+    ``"measured"`` so every pre-existing caller keeps its current behaviour.
+    ``estimated_usd`` (mixed-provenance fix) is likewise forwarded unchanged;
+    when omitted, behaviour is unchanged from before this fix.
     """
-    record_cost(state, cost_usd, cost_tokens)
+    record_cost(state, cost_usd, cost_tokens, source=source, estimated_usd=estimated_usd)
     block = should_block_for_budget(state)
     downgrade = should_downgrade_model(state)
     return block, downgrade
@@ -65,6 +109,7 @@ def charge_and_gate_repo(
     repo_id: str | None,
     cost_usd: float,
     cost_tokens: int,
+    source: str = "measured",
 ) -> tuple[bool, bool, bool]:
     """WS8 SLICE 4 — per-repo fleet budget isolation.
 
@@ -87,7 +132,7 @@ def charge_and_gate_repo(
       extension is addable without schema changes.  Per-repo over must NEVER be
       wired into the fleet-WIDE cancel_event — that would break isolation.
     """
-    record_cost(state, cost_usd, cost_tokens)
+    record_cost(state, cost_usd, cost_tokens, source=source)
 
     # Per-repo spend tracking.
     # If repo_id is None OR the repo has no per-repo allocation (not a fleet

--- a/hydra_core/host_bridge.py
+++ b/hydra_core/host_bridge.py
@@ -1671,6 +1671,18 @@ def _step_result(cursor: dict[str, Any], cursor_file: str | Path) -> dict[str, A
         "cost_usd": float(cursor.get("cost_usd") or 0.0),
         "tokens_in": int(cursor.get("tokens_in") or 0),
         "tokens_out": int(cursor.get("tokens_out") or 0),
+        # B8: cost provenance for the stage as a whole — the CLI's
+        # charge_and_gate call reads "cost_source" to tag the ledger entry so
+        # an unreporting host counts as estimated/unmeasured, never free.
+        # Defaults to "measured" (pre-existing behaviour) when the stage never
+        # ran any accrual (e.g. still awaiting the host).
+        "cost_source": cursor.get("cost_source") or "measured",
+        "unmeasured_count": int(cursor.get("unmeasured_count") or 0),
+        # Fix (mixed-provenance estimated_usd): the per-component estimated
+        # dollars accrued across this stage's calls, so a charging site can
+        # credit budget.estimated_usd with only this figure instead of
+        # inferring it from the collapsed "cost_source" label.
+        "estimated_cost_usd": float(cursor.get("estimated_cost_usd") or 0.0),
     }
     if status == "awaiting_host":
         res["host_action"] = _host_action(cursor)
@@ -1728,6 +1740,81 @@ def _trace(cursor: dict[str, Any], kind: str, payload: dict[str, Any]) -> None:
                         {"run_id": cursor.get("run_id"), **payload})
     except Exception:  # noqa: BLE001 — never crash the driver on a trace write
         pass
+
+
+# B8: priority order used to resolve one stage's overall cost provenance
+# across its several accrual calls (generate, judge, squad-result) —
+# "estimated" wins over "measured" wins over "unmeasured", because a single
+# estimated call anywhere in the stage means the stage's total cost_usd is no
+# longer purely measured money, and a single measured call means the stage is
+# not wholly unmeasured.
+_SOURCE_RANK = {"unmeasured": 0, "measured": 1, "estimated": 2}
+
+
+def _merge_cost_source(cursor: dict[str, Any], new_source: str) -> None:
+    current = cursor.get("cost_source")
+    if current is None or _SOURCE_RANK[new_source] > _SOURCE_RANK[current]:
+        cursor["cost_source"] = new_source
+
+
+def _priced_cost(
+    cursor: dict[str, Any],
+    result: dict[str, Any],
+    *,
+    label: str,
+    model_hint: str | None = None,
+) -> tuple[float, str]:
+    """B8: resolve a host result's dollar cost + provenance ``source``.
+
+    Returns ``(cost_usd, source)`` where ``source`` is one of
+    ``"measured"`` (the host reported ``cost_usd`` directly — the pre-existing
+    behaviour, unchanged), ``"estimated"`` (the host reported no cost but DID
+    report ``tokens_in``/``tokens_out`` and a ``model``, so
+    ``hydra_core.pricing.price_call`` prices it), or ``"unmeasured"`` (neither
+    a cost nor usable tokens+model were reported — this call contributes
+    $0.0 and a trace event is emitted; it never blocks the stage).
+
+    Also folds the resolved source into ``cursor["cost_source"]`` — priority
+    estimated > measured > unmeasured across the whole stage's accrual calls
+    (generate + judge + squad-result) — and bumps ``cursor["unmeasured_count"]``
+    on an unmeasured call so a caller charging the STAGE's total cost once
+    (``_cmd_attended_submit`` / recover-stalled-stage) can pick the right
+    ``source`` for ``charge_and_gate``.
+
+    Fix (mixed-provenance ``estimated_usd``): a stage can mix a measured call
+    (e.g. generate) with an estimated call (e.g. judge). ``cost_source``
+    necessarily collapses to a single winning label for the whole stage
+    (see ``_merge_cost_source``), so it cannot tell the charging site how much
+    of the stage's *total* was actually estimated money. This function
+    separately accumulates ``cursor["estimated_cost_usd"]`` by ONLY the
+    dollar amount resolved on this call's estimated branch, so a caller can
+    credit ``budget.estimated_usd`` with just that figure instead of the
+    whole (mixed) stage total.
+    """
+    reported = result.get("cost_usd")
+    if reported is not None:
+        _merge_cost_source(cursor, "measured")
+        return float(reported), "measured"
+
+    tokens_in = int(result.get("tokens_in") or 0)
+    tokens_out = int(result.get("tokens_out") or 0)
+    model = str(result.get("model") or model_hint or cursor.get("model_tier") or "")
+    if (tokens_in or tokens_out) and model:
+        from .pricing import price_call
+        priced = price_call(model, tokens_in, tokens_out)
+        if priced is not None:
+            _merge_cost_source(cursor, "estimated")
+            cursor["estimated_cost_usd"] = (
+                float(cursor.get("estimated_cost_usd") or 0.0) + priced
+            )
+            return priced, "estimated"
+
+    _merge_cost_source(cursor, "unmeasured")
+    cursor["unmeasured_count"] = int(cursor.get("unmeasured_count") or 0) + 1
+    _trace(cursor, "attended.cost_unmeasured", {
+        "stage_id": cursor.get("stage_id"), "call": label, "model": model or None,
+    })
+    return 0.0, "unmeasured"
 
 
 # --------------------------------------------------------------------------- #
@@ -1891,7 +1978,11 @@ def _apply_generate(dispatcher: Dispatcher, cursor: dict[str, Any],
     producer = cursor["producer"]
 
     gen_text = str(result.get("text") or "")
-    cursor["cost_usd"] = float(cursor["cost_usd"]) + float(result.get("cost_usd") or 0.0)
+    # B8: a host result that omits cost_usd is no longer free — if it reports
+    # tokens+model, price it (source="estimated"); otherwise it is
+    # source="unmeasured" ($0.0, logged, non-blocking).
+    _gen_cost, _gen_source = _priced_cost(cursor, result, label="generate")
+    cursor["cost_usd"] = float(cursor["cost_usd"]) + _gen_cost
     cursor["tokens_in"] = int(cursor["tokens_in"]) + int(result.get("tokens_in") or 0)
     cursor["tokens_out"] = int(cursor["tokens_out"]) + int(result.get("tokens_out") or 0)
 
@@ -1930,7 +2021,7 @@ def _apply_generate(dispatcher: Dispatcher, cursor: dict[str, Any],
                     "agent_type": "engineer",   # F29
                     "tokens_in": int(result.get("tokens_in") or 0),
                     "tokens_out": int(result.get("tokens_out") or 0),
-                    "cost_usd": float(result.get("cost_usd") or 0.0),
+                    "cost_usd": _gen_cost,
                     "status": "error", "retry_index": gen_idx,
                     "notes": {"candidate_index": 1},
                 }, squad_id=_SQ),
@@ -1972,7 +2063,7 @@ def _apply_generate(dispatcher: Dispatcher, cursor: dict[str, Any],
                 "agent_type": "engineer",   # F29 — accepted optional; strict rejects 'general-purpose'
                 "tokens_in": int(result.get("tokens_in") or 0),
                 "tokens_out": int(result.get("tokens_out") or 0),
-                "cost_usd": float(result.get("cost_usd") or 0.0),
+                "cost_usd": _gen_cost,
                 "status": "ok", "retry_index": gen_idx,
                 "notes": {"candidate_index": 1},
             }, squad_id=_SQ),
@@ -2260,7 +2351,15 @@ def _apply_judge(dispatcher: Dispatcher, cursor: dict[str, Any],
                             "judge_cost_applied_for double-counting guard "
                             "cannot protect this accrual on a re-drive"),
             })
-        cursor["cost_usd"] = float(cursor["cost_usd"]) + float(result.get("cost_usd") or 0.0)
+        # B8: same treat-missing-cost-as-priceable-or-unmeasured policy as the
+        # generate accrual above; hint the judge's own model field
+        # (judge_model_id) since a judge result's model lives there, not in
+        # the generic "model" key.
+        _judge_cost, _judge_cost_source = _priced_cost(
+            cursor, result, label="judge",
+            model_hint=str(result.get("judge_model_id") or "") or None,
+        )
+        cursor["cost_usd"] = float(cursor["cost_usd"]) + _judge_cost
         cursor["tokens_in"] = int(cursor["tokens_in"]) + int(result.get("tokens_in") or 0)
         cursor["tokens_out"] = int(cursor["tokens_out"]) + int(result.get("tokens_out") or 0)
         if call_key is not None:
@@ -3043,8 +3142,10 @@ def _apply_squad_result(
     (``_cmd_attended_submit``) charges the returned cost_usd through the
     authoritative HydraState budget path after this returns.
     """
-    cursor["cost_usd"] = (float(cursor.get("cost_usd") or 0.0)
-                          + float(result.get("cost_usd") or 0.0))
+    # B8: same treat-missing-cost-as-priceable-or-unmeasured policy as the
+    # engineering generate/judge accruals above.
+    _squad_cost, _squad_cost_source = _priced_cost(cursor, result, label="squad_result")
+    cursor["cost_usd"] = float(cursor.get("cost_usd") or 0.0) + _squad_cost
     cursor["tokens_in"] = (int(cursor.get("tokens_in") or 0)
                            + int(result.get("tokens_in") or 0))
     cursor["tokens_out"] = (int(cursor.get("tokens_out") or 0)

--- a/hydra_core/pricing.py
+++ b/hydra_core/pricing.py
@@ -1,0 +1,139 @@
+"""Model pricing table + call-cost estimation (B8 fix support).
+
+``hydra_core`` stays runtime-agnostic: this module knows *rates*, not any
+vendor's billing API, and imports no provider SDK.
+
+A host result that reports ``tokens_in``/``tokens_out``/``model`` but not a
+measured ``cost_usd`` can still be *priced* here so the budget tripwires
+(``should_downgrade_model`` / ``should_block_for_budget``) see an honest
+estimate instead of silently treating the call as free. See
+``hydra_core.governance.record_cost`` (``source="estimated"``) for how a
+priced call is folded into the ledger.
+
+Resolution order for a model id's rate:
+  1. an operator override file at ``<HYDRA_HOME>/pricing.json``, merged OVER
+     the built-in table (an id present in the override wins).
+  2. the built-in table below.
+
+``HYDRA_HOME`` is resolved from ``os.environ`` **at call time**, inside
+``_load_override_table``, never at import — unlike ``hydra_core/memory.py``
+(module-level ``HYDRA_HOME = os.environ.get(...)``), which forces
+``tests/conftest.py`` to compensate for the stale binding. Reading the env var
+per-call means a test (or host) that sets ``HYDRA_HOME`` after this module has
+already been imported still gets the override.
+
+A model id absent from both tables is NOT an error: ``get_rate``/``price_call``
+return ``None``, which callers must treat as *unmeasured*, never as free. A
+malformed or unreadable override file is also not an error: it is ignored and
+the built-in table is used.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ModelRate:
+    """Per-million-token USD rates, mirroring vendor list pricing.
+
+    ``cache_write_per_mtok``/``cache_read_per_mtok`` default to 0.0 for a
+    vendor/model that publishes no separate cache rate (a cache-token count
+    of 0 then contributes nothing, which is the correct behaviour for a
+    model with no cache tier).
+    """
+
+    input_per_mtok: float
+    output_per_mtok: float
+    cache_write_per_mtok: float = 0.0
+    cache_read_per_mtok: float = 0.0
+
+
+# Seeded with the model ids this repo already names:
+#   - Claude host-session ids (this attended engineering harness runs on
+#     Claude Code; see CLAUDE.md / session attribution for the live ids).
+#     Sonnet rates are the published list rates ($3/$15/$3.75/$0.30 per
+#     Mtok in/out/cache-write/cache-read); the sibling tiers are scaled
+#     from that anchor since Anthropic has not published separate public
+#     list rates for these particular ids at authoring time.
+#   - codex judge pins from ``host_bridge._STATIC_JUDGE_MODEL_PINS["codex"]``.
+#   - agy (gemini) judge pins from
+#     ``host_bridge._STATIC_JUDGE_MODEL_PINS["agy"]``.
+_BUILTIN_RATES: dict[str, ModelRate] = {
+    "claude-sonnet-5": ModelRate(3.0, 15.0, 3.75, 0.30),
+    "claude-opus-5": ModelRate(15.0, 75.0, 18.75, 1.50),
+    "claude-fable-5-1": ModelRate(3.0, 15.0, 3.75, 0.30),
+    "claude-haiku-4-5-20251001": ModelRate(0.80, 4.0, 1.0, 0.08),
+    "gpt-5.6-terra": ModelRate(1.75, 14.0),
+    "gpt-5.6-sol": ModelRate(1.75, 14.0),
+    "gemini-3.8-flash-medium": ModelRate(0.30, 2.50),
+    "gemini-3.1-pro-high": ModelRate(1.25, 10.0),
+}
+
+
+def _load_override_table() -> dict[str, ModelRate]:
+    """Read ``<HYDRA_HOME>/pricing.json``, resolved from ``os.environ`` NOW.
+
+    Returns ``{}`` on any error — missing file, unreadable path, malformed
+    JSON, or a per-model entry with the wrong shape — so a bad override file
+    never crashes the engine; it just means no override applies.
+    """
+    home = os.environ.get("HYDRA_HOME") or str(Path.home() / ".hydra")
+    path = Path(home) / "pricing.json"
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001 — missing/unreadable/malformed file: no override
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, ModelRate] = {}
+    for model_id, spec in raw.items():
+        if not isinstance(spec, dict):
+            continue
+        try:
+            out[str(model_id)] = ModelRate(
+                input_per_mtok=float(spec["input_per_mtok"]),
+                output_per_mtok=float(spec["output_per_mtok"]),
+                cache_write_per_mtok=float(spec.get("cache_write_per_mtok", 0.0)),
+                cache_read_per_mtok=float(spec.get("cache_read_per_mtok", 0.0)),
+            )
+        except Exception:  # noqa: BLE001 — one bad entry does not poison the rest
+            continue
+    return out
+
+
+def get_rate(model_id: str) -> Optional[ModelRate]:
+    """Resolve ``model_id``'s rate: override table wins, else builtin, else None."""
+    overrides = _load_override_table()
+    if model_id in overrides:
+        return overrides[model_id]
+    return _BUILTIN_RATES.get(model_id)
+
+
+def price_call(
+    model_id: str,
+    tokens_in: int,
+    tokens_out: int,
+    *,
+    cache_write_tokens: int = 0,
+    cache_read_tokens: int = 0,
+) -> Optional[float]:
+    """Price one call's token usage in USD, or ``None`` if ``model_id`` is unknown.
+
+    ``None`` is NOT an error — callers (``hydra_core/host_bridge.py``,
+    ``hydra_core/transcript_cost.py``) must treat an unknown model as
+    *unmeasured*, never as a free ($0.0) call.
+    """
+    rate = get_rate(model_id)
+    if rate is None:
+        return None
+    cost = (
+        tokens_in * rate.input_per_mtok
+        + tokens_out * rate.output_per_mtok
+        + cache_write_tokens * rate.cache_write_per_mtok
+        + cache_read_tokens * rate.cache_read_per_mtok
+    ) / 1_000_000.0
+    return round(cost, 8)

--- a/hydra_core/state.py
+++ b/hydra_core/state.py
@@ -27,6 +27,16 @@ class BudgetLedger(BaseModel):
     spent_usd: float = 0.0
     spent_tokens: int = 0
 
+    # B8: companion counters for cost provenance. ``estimated_usd`` is the
+    # portion of ``spent_usd`` that came from ``pricing.price_call`` rather
+    # than a directly reported ``cost_usd`` (source="estimated" in
+    # ``record_cost``) — a companion, never a substitute: ``spent_usd``
+    # keeps its existing meaning and the 0.8/1.0 tripwires read it unchanged.
+    # ``unmeasured_stages`` counts stages that reported neither a cost nor
+    # usable tokens (source="unmeasured") — logged, never blocking.
+    estimated_usd: float = 0.0
+    unmeasured_stages: int = 0
+
     # WS8 SLICE 4 — per-repo fleet budget isolation.
     # repo_budgets: equal-split allocation per fleet repo (set by allocate_repos).
     # repo_spend:   accumulated spend per fleet repo (updated by charge_and_gate_repo).

--- a/hydra_core/transcript_cost.py
+++ b/hydra_core/transcript_cost.py
@@ -1,0 +1,146 @@
+"""Sum + price a subagent transcript's per-turn token usage (Part 5, B8).
+
+A host driving ``hydra.workflow.plan`` / ``hydra.workflow.step`` /
+``hydra.workflow.submit_host_result`` spawns an anonymous subagent (e.g. an
+``Agent`` tool call) whose transcript is a JSONL file — one JSON object per
+line — where each assistant turn carries a ``message`` object with a
+``usage`` block (``input_tokens``, ``output_tokens``,
+``cache_creation_input_tokens``, ``cache_read_input_tokens``) and a
+``model`` id. This module sums that usage across every turn and prices it
+through ``hydra_core.pricing`` so the host can report a *real* ``cost_usd``
+to ``submit_host_result`` instead of omitting it (which — see B8 — used to
+be silently treated as a $0.0 stage).
+
+Any host driving the attended engineering loop should use
+``summarize_transcript_cost`` rather than re-deriving this ad hoc; it is the
+same technique used to reconstruct a real ``cost_usd`` for an engineer/judge
+subagent that does not self-report spend.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .pricing import price_call
+
+
+@dataclass
+class TranscriptCostSummary:
+    """Aggregate token usage + priced cost for one subagent transcript.
+
+    ``cost_usd`` only includes turns whose model was priceable (present in
+    ``hydra_core.pricing``'s built-in table or the ``HYDRA_HOME`` override).
+    ``unpriced_models`` lists any model id seen in the transcript that could
+    not be priced — those turns' tokens still count toward
+    ``tokens_in``/``tokens_out``/etc, but contribute $0.0 to ``cost_usd``, so
+    a caller can tell whether the total is a complete or partial estimate.
+    """
+
+    tokens_in: int = 0
+    tokens_out: int = 0
+    cache_write_tokens: int = 0
+    cache_read_tokens: int = 0
+    cost_usd: float = 0.0
+    turns: int = 0
+    unpriced_models: set[str] = field(default_factory=set)
+
+    @property
+    def fully_priced(self) -> bool:
+        """True when every turn with a known model contributed to cost_usd."""
+        return not self.unpriced_models
+
+
+def _iter_turn_usage(path: str | Path) -> list[tuple[str, dict[str, Any]]]:
+    """Yield (model, usage_dict) for every line with a usable ``message.usage``.
+
+    Malformed lines (non-JSON, missing ``message``/``usage``) are skipped —
+    a corrupt or partial transcript must not crash the caller; it just
+    contributes less data to the summary.
+    """
+    out: list[tuple[str, dict[str, Any]]] = []
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError:
+        return out
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(obj, dict):
+            continue
+        message = obj.get("message")
+        if not isinstance(message, dict):
+            continue
+        usage = message.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        model = str(message.get("model") or "")
+        out.append((model, usage))
+    return out
+
+
+def _safe_int(value: Any) -> int:
+    """Coerce a usage field to ``int``, tolerating malformed JSON values.
+
+    A syntactically valid JSONL line can still carry a non-integer token
+    value (a string, a nested object, a list, ``None``) — this module's own
+    docstring promises tolerance of malformed lines, so a value that cannot
+    be interpreted as a whole number of tokens contributes 0 rather than
+    raising ``TypeError``/``ValueError`` out of ``int(...)``.
+    """
+    if isinstance(value, bool):
+        # bool is an int subclass; treat it like any other non-numeric junk.
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            try:
+                return int(float(value.strip()))
+            except (ValueError, TypeError):
+                return 0
+    return 0
+
+
+def summarize_transcript_cost(path: str | Path) -> TranscriptCostSummary:
+    """Sum + price every turn's usage in a subagent transcript JSONL file.
+
+    A missing/unreadable file or one with no usable ``message.usage`` lines
+    yields a zeroed summary (``turns=0``) rather than raising — the caller
+    treats a zeroed summary the same way ``hydra_core.host_bridge`` treats an
+    unreportable host result: unmeasured, not an error.
+    """
+    summary = TranscriptCostSummary()
+    for model, usage in _iter_turn_usage(path):
+        tin = _safe_int(usage.get("input_tokens"))
+        tout = _safe_int(usage.get("output_tokens"))
+        cache_write = _safe_int(usage.get("cache_creation_input_tokens"))
+        cache_read = _safe_int(usage.get("cache_read_input_tokens"))
+
+        summary.turns += 1
+        summary.tokens_in += tin
+        summary.tokens_out += tout
+        summary.cache_write_tokens += cache_write
+        summary.cache_read_tokens += cache_read
+
+        if not model:
+            continue
+        priced = price_call(
+            model, tin, tout,
+            cache_write_tokens=cache_write, cache_read_tokens=cache_read,
+        )
+        if priced is None:
+            summary.unpriced_models.add(model)
+            continue
+        summary.cost_usd += priced
+
+    summary.cost_usd = round(summary.cost_usd, 8)
+    return summary

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -939,7 +939,7 @@ def test_attended_squad_path_completes_charges_once_no_redispatch(
     monkeypatch.setattr("hydra_core.squad_loader.discover_squads",
                         lambda *a, **k: {"garland": _FakePack()})
     monkeypatch.setattr("hydra_core.governance.charge_and_gate",
-                        lambda state, cost, toks: (False, False))
+                        lambda state, cost, toks, **_kw: (False, False))
 
     # --- step 1: attended step → squad cursor ---
     rc_step = cli._cmd_attended_step(

--- a/tests/test_cost_provenance.py
+++ b/tests/test_cost_provenance.py
@@ -1,0 +1,395 @@
+"""B8 — cost provenance: an unreporting host must not be treated as free.
+
+Covers:
+  1. record_cost source semantics: measured -> spent_usd only; estimated ->
+     BOTH spent_usd and estimated_usd; unmeasured -> unmeasured_stages++.
+  2. The 0.8/1.0 budget tripwires fire on estimated spend, not just measured.
+  3. pricing.price_call: known model prices correctly, unknown model returns
+     None (never raises, never silently prices as $0 without signalling).
+  4. pricing._load_override_table / get_rate: HYDRA_HOME is read at CALL TIME
+     (a test that sets the env var AFTER import still sees the override), and
+     a malformed pricing.json degrades to the builtin table without raising.
+  5. charge_and_gate_repo still reconciles sum(repo_spend.values()) against
+     spent_usd when charged with source="estimated".
+  6. host_bridge._priced_cost: measured/estimated/unmeasured resolution from a
+     host result dict, and the stage-level cost_source priority merge
+     (estimated > measured > unmeasured).
+
+No network, no LLM calls, hermetic per tests/conftest.py (HYDRA_HOME already
+redirected to .tmp-pytest/hydra-home by the session-scoped fixture).
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hydra_core import pricing
+from hydra_core.governance import (
+    charge_and_gate,
+    charge_and_gate_repo,
+    record_cost,
+    should_block_for_budget,
+    should_downgrade_model,
+)
+from hydra_core.host_bridge import _priced_cost
+from hydra_core.state import BudgetLedger, HydraState
+
+
+def _state(budget: float = 10.0) -> HydraState:
+    return HydraState(root_goal="cost-provenance-test", budget=BudgetLedger(budget_usd=budget))
+
+
+# ---------------------------------------------------------------------------
+# 1. record_cost source semantics
+# ---------------------------------------------------------------------------
+
+class TestRecordCostSource:
+    def test_measured_charge_lands_only_in_spent_usd(self) -> None:
+        state = _state()
+        record_cost(state, 2.0, 1000, source="measured")
+        assert state.budget.spent_usd == pytest.approx(2.0)
+        assert state.budget.estimated_usd == pytest.approx(0.0)
+        assert state.budget.unmeasured_stages == 0
+
+    def test_estimated_charge_lands_in_both_counters(self) -> None:
+        state = _state()
+        record_cost(state, 2.0, 1000, source="estimated")
+        assert state.budget.spent_usd == pytest.approx(2.0)
+        assert state.budget.estimated_usd == pytest.approx(2.0)
+        assert state.budget.unmeasured_stages == 0
+
+    def test_unmeasured_increments_stage_counter_and_charges_nothing(self) -> None:
+        state = _state()
+        record_cost(state, 0.0, 0, source="unmeasured")
+        assert state.budget.spent_usd == pytest.approx(0.0)
+        assert state.budget.estimated_usd == pytest.approx(0.0)
+        assert state.budget.unmeasured_stages == 1
+
+    def test_default_source_is_measured_for_pre_existing_callers(self) -> None:
+        # FALSIFIABILITY: revert record_cost's `source: str = "measured"`
+        # default to a positional-only signature (i.e. undo the B8 fix) and
+        # this call becomes a TypeError -- proving every pre-existing
+        # 2-arg caller (cli.py, ingest.py, supervisor.py) still compiles
+        # and behaves exactly as before.
+        state = _state()
+        record_cost(state, 1.0, 10)  # no `source` kwarg at all
+        assert state.budget.spent_usd == pytest.approx(1.0)
+        assert state.budget.estimated_usd == pytest.approx(0.0)
+        assert state.budget.unmeasured_stages == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Tripwires fire on estimated spend
+# ---------------------------------------------------------------------------
+
+class TestTripwiresOnEstimatedSpend:
+    """These tests DERIVE the charged dollar figure from a host-result dict
+    via `_priced_cost` (tokens_in/tokens_out/model, no cost_usd) rather than
+    handing `record_cost` a dollar amount directly. Handing in a bare dollar
+    figure would make the tripwire assertion true regardless of whether B8's
+    estimation plumbing exists at all -- the point is that an UNREPORTED cost
+    still moves the gate, and only routing through `_priced_cost` proves that.
+    """
+
+    def test_downgrade_tripwire_fires_on_priced_estimate(self) -> None:
+        # Sonnet: $3/Mtok in + $15/Mtok out -> 1M in + 1M out = $18.00.
+        # Budget $20 -> percent_consumed = 0.90, past the 0.8 downgrade line
+        # but under 1.0, so block must stay False.
+        cursor: dict = {"stage_id": "s1", "project_path": ".", "workflow_id": None}
+        result = {"tokens_in": 1_000_000, "tokens_out": 1_000_000, "model": "claude-sonnet-5"}
+        cost, source = _priced_cost(cursor, result, label="generate")
+        assert source == "estimated"
+        assert cost == pytest.approx(18.0)
+
+        state = _state(budget=20.0)
+        record_cost(state, cost, 2_000_000, source=source)
+        assert state.budget.percent_consumed == pytest.approx(0.90)
+        assert should_downgrade_model(state) is True
+        assert should_block_for_budget(state) is False
+
+    def test_block_tripwire_fires_on_priced_estimate(self) -> None:
+        # Same priced $18.00, but against a $18 budget -> percent_consumed
+        # == 1.0 exactly, which the >= comparison in should_block_for_budget
+        # must treat as blocking.
+        cursor: dict = {"stage_id": "s1", "project_path": ".", "workflow_id": None}
+        result = {"tokens_in": 1_000_000, "tokens_out": 1_000_000, "model": "claude-sonnet-5"}
+        cost, source = _priced_cost(cursor, result, label="generate")
+        assert source == "estimated"
+
+        state = _state(budget=18.0)
+        record_cost(state, cost, 2_000_000, source=source)
+        assert should_block_for_budget(state) is True
+
+
+# ---------------------------------------------------------------------------
+# 2b. End-to-end: unreported host result -> _priced_cost -> charge_and_gate
+# ---------------------------------------------------------------------------
+
+class TestPricedEstimateReachesChargeAndGate:
+    """The plumbing can be individually correct (`_priced_cost` returns a
+    priced tuple; `charge_and_gate` moves counters given a number) while still
+    being DISCONNECTED -- e.g. a caller that drops the returned `source` on
+    the floor and always charges "measured". This test wires the two
+    together exactly as `hydra_core/cli.py`'s attended charge sites do, so a
+    regression that breaks that connection (not either half in isolation)
+    fails here.
+    """
+
+    def test_unreported_cost_reaches_charge_and_gate_as_estimate(self) -> None:
+        cursor: dict = {"stage_id": "s1", "project_path": ".", "workflow_id": None}
+        result = {"tokens_in": 1_000_000, "tokens_out": 1_000_000, "model": "claude-sonnet-5"}
+        # No "cost_usd" key anywhere in `result` -- this is the exact shape of
+        # an unreporting host's submit_host_result payload.
+        assert "cost_usd" not in result
+
+        cost, source = _priced_cost(cursor, result, label="generate")
+        toks = int(result["tokens_in"]) + int(result["tokens_out"])
+
+        state = _state(budget=20.0)
+        block, downgrade = charge_and_gate(state, cost, toks, source=source)
+
+        assert downgrade is True
+        assert block is False
+        assert state.budget.estimated_usd == pytest.approx(18.0)
+        assert state.budget.estimated_usd > 0.0
+
+
+# ---------------------------------------------------------------------------
+# 3. pricing.price_call
+# ---------------------------------------------------------------------------
+
+class TestPriceCall:
+    def test_known_model_prices_correctly(self) -> None:
+        # Sonnet list rates: $3/Mtok in, $15/Mtok out.
+        cost = pricing.price_call("claude-sonnet-5", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(18.0)
+
+    def test_known_model_with_cache_tokens(self) -> None:
+        cost = pricing.price_call(
+            "claude-sonnet-5", 0, 0,
+            cache_write_tokens=1_000_000, cache_read_tokens=1_000_000,
+        )
+        assert cost == pytest.approx(3.75 + 0.30)
+
+    def test_unknown_model_returns_none_and_does_not_raise(self) -> None:
+        # FALSIFIABILITY: a naive implementation that defaults an unknown
+        # rate to ModelRate(0.0, 0.0) instead of returning None would make
+        # this `is None` assertion fail (it would return 0.0 instead).
+        assert pricing.price_call("totally-unheard-of-model-xyz", 1000, 1000) is None
+        assert pricing.get_rate("totally-unheard-of-model-xyz") is None
+
+
+# ---------------------------------------------------------------------------
+# 4. HYDRA_HOME call-time resolution + malformed override resilience
+# ---------------------------------------------------------------------------
+
+class TestPricingOverride:
+    def test_hydra_home_is_read_at_call_time_not_import_time(self, tmp_path: Path, monkeypatch) -> None:
+        # FALSIFIABILITY: if hydra_core.pricing bound HYDRA_HOME at import
+        # time (the hydra_core/memory.py anti-pattern this fix explicitly
+        # avoids), setting the env var here -- long after pricing was
+        # imported at module load -- would have no effect, and the override
+        # rate below would never be picked up: this assertion would see the
+        # builtin table's price ($18.0 for 1M/1M sonnet tokens) instead.
+        override = {
+            "claude-sonnet-5": {
+                "input_per_mtok": 999.0,
+                "output_per_mtok": 999.0,
+            }
+        }
+        (tmp_path / "pricing.json").write_text(json.dumps(override), encoding="utf-8")
+        monkeypatch.setenv("HYDRA_HOME", str(tmp_path))
+        cost = pricing.price_call("claude-sonnet-5", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(999.0 + 999.0)
+
+    def test_malformed_override_file_falls_back_to_builtin(self, tmp_path: Path, monkeypatch) -> None:
+        (tmp_path / "pricing.json").write_text("{not valid json!!", encoding="utf-8")
+        monkeypatch.setenv("HYDRA_HOME", str(tmp_path))
+        # FALSIFIABILITY: without the try/except around json.loads in
+        # _load_override_table, this call raises json.JSONDecodeError instead
+        # of returning the builtin-table price.
+        cost = pricing.price_call("claude-sonnet-5", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(18.0)
+
+    def test_missing_override_file_falls_back_to_builtin(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("HYDRA_HOME", str(tmp_path / "does-not-exist"))
+        cost = pricing.price_call("claude-sonnet-5", 1000, 1000)
+        assert cost is not None
+
+
+# ---------------------------------------------------------------------------
+# 5. charge_and_gate_repo reconciliation with source="estimated"
+# ---------------------------------------------------------------------------
+
+class TestChargeAndGateRepoReconciles:
+    def test_reconciles_sum_repo_spend_against_spent_usd_estimated(self) -> None:
+        state = _state(budget=30.0)
+        state.budget.allocate_repos(["repo-a", "repo-b"])
+        charge_and_gate_repo(state, "repo-a", 3.0, 100, source="estimated")
+        charge_and_gate_repo(state, "repo-b", 4.0, 100, source="measured")
+        charge_and_gate_repo(state, None, 1.0, 0, source="unmeasured")
+        total_repo_spend = sum(state.budget.repo_spend.values())
+        assert total_repo_spend == pytest.approx(state.budget.spent_usd)
+        assert state.budget.spent_usd == pytest.approx(8.0)
+        assert state.budget.estimated_usd == pytest.approx(3.0)
+        assert state.budget.unmeasured_stages == 1
+
+
+# ---------------------------------------------------------------------------
+# 6. host_bridge._priced_cost resolution + stage-level source priority
+# ---------------------------------------------------------------------------
+
+class TestPricedCostResolution:
+    def _cursor(self) -> dict:
+        return {"stage_id": "stage-1", "project_path": ".", "workflow_id": None}
+
+    def test_measured_when_host_reports_cost_usd(self) -> None:
+        cursor = self._cursor()
+        cost, source = _priced_cost(cursor, {"cost_usd": 1.23}, label="generate")
+        assert source == "measured"
+        assert cost == pytest.approx(1.23)
+        assert cursor["cost_source"] == "measured"
+
+    def test_estimated_when_tokens_and_model_present_but_no_cost(self) -> None:
+        # FALSIFIABILITY: before this fix, host_bridge did
+        # `float(result.get("cost_usd") or 0.0)` unconditionally -- a result
+        # with tokens_in=1_000_000/tokens_out=1_000_000/model=claude-sonnet-5
+        # and NO cost_usd key would price at $0.0, not $18.0.
+        cursor = self._cursor()
+        result = {"tokens_in": 1_000_000, "tokens_out": 1_000_000, "model": "claude-sonnet-5"}
+        cost, source = _priced_cost(cursor, result, label="generate")
+        assert source == "estimated"
+        assert cost == pytest.approx(18.0)
+        assert cursor["cost_source"] == "estimated"
+
+    def test_unmeasured_when_no_cost_and_no_priceable_tokens(self) -> None:
+        cursor = self._cursor()
+        cost, source = _priced_cost(cursor, {}, label="generate")
+        assert source == "unmeasured"
+        assert cost == 0.0
+        assert cursor["cost_source"] == "unmeasured"
+        assert cursor["unmeasured_count"] == 1
+
+    def test_unmeasured_when_tokens_present_but_model_unknown(self) -> None:
+        cursor = self._cursor()
+        result = {"tokens_in": 1000, "tokens_out": 1000, "model": "no-such-model"}
+        cost, source = _priced_cost(cursor, result, label="generate")
+        assert source == "unmeasured"
+        assert cost == 0.0
+
+    def test_stage_source_priority_estimated_beats_measured(self) -> None:
+        # A stage where the generate call was measured but the judge call was
+        # only priceable (estimated) must resolve the STAGE's cost_source to
+        # "estimated" -- estimated outranks measured, per the merge policy.
+        cursor = self._cursor()
+        _priced_cost(cursor, {"cost_usd": 0.50}, label="generate")
+        assert cursor["cost_source"] == "measured"
+        _priced_cost(
+            cursor,
+            {"tokens_in": 500_000, "tokens_out": 500_000, "model": "claude-sonnet-5"},
+            label="judge",
+        )
+        assert cursor["cost_source"] == "estimated"
+
+    def test_stage_source_priority_measured_beats_unmeasured(self) -> None:
+        cursor = self._cursor()
+        _priced_cost(cursor, {}, label="generate")
+        assert cursor["cost_source"] == "unmeasured"
+        _priced_cost(cursor, {"cost_usd": 0.1}, label="judge")
+        assert cursor["cost_source"] == "measured"
+
+
+# ---------------------------------------------------------------------------
+# 7. Mixed-provenance stage: estimated_usd must equal ONLY the estimated
+#    component, never the collapsed-label stage total.
+# ---------------------------------------------------------------------------
+
+class TestMixedProvenanceEstimatedUsd:
+    """A single stage can accrue a MEASURED component (e.g. generate reports
+    cost_usd directly) and an ESTIMATED component (e.g. judge reports only
+    tokens+model) on the SAME cursor. `_merge_cost_source` necessarily
+    collapses `cursor["cost_source"]` to one winning label ("estimated" beats
+    "measured") for the whole stage -- charging the STAGE TOTAL under that
+    single collapsed label overstates `budget.estimated_usd` by the measured
+    component, because `record_cost(source="estimated")` used to credit the
+    WHOLE amount, not just the estimated portion.
+    """
+
+    def test_charging_stage_total_under_collapsed_source_overstates_estimated_usd(
+        self,
+    ) -> None:
+        cursor: dict = {"stage_id": "s1", "project_path": ".", "workflow_id": None}
+
+        # Measured component: generate reports cost_usd=2.50 directly.
+        gen_cost, gen_source = _priced_cost(cursor, {"cost_usd": 2.50}, label="generate")
+        assert gen_source == "measured"
+        assert gen_cost == pytest.approx(2.50)
+
+        # Estimated component: judge reports only tokens+model -> priced by
+        # hydra_core.pricing (Sonnet: 1M in + 1M out = $18.00).
+        judge_result = {
+            "tokens_in": 1_000_000, "tokens_out": 1_000_000, "model": "claude-sonnet-5",
+        }
+        judge_cost, judge_source = _priced_cost(cursor, judge_result, label="judge")
+        assert judge_source == "estimated"
+        assert judge_cost == pytest.approx(18.0)
+
+        # The stage's collapsed label is "estimated" (estimated outranks
+        # measured), and the stage TOTAL is the sum of both components --
+        # exactly what cli.py's charging sites compute and forward.
+        assert cursor["cost_source"] == "estimated"
+        stage_total = gen_cost + judge_cost
+        assert stage_total == pytest.approx(20.50)
+
+        # `_priced_cost` tracked the estimated-only component separately.
+        estimated_component = float(cursor.get("estimated_cost_usd") or 0.0)
+        assert estimated_component == pytest.approx(18.0)
+
+        # Charge exactly as cli.py's _cmd_attended_submit / recover-stalled
+        # sites do: pass the per-component figure through charge_and_gate's
+        # `estimated_usd` kwarg rather than letting the amount be inferred
+        # from the collapsed `cost_source` label.
+        state = _state(budget=100.0)
+        charge_and_gate(
+            state, stage_total, 2_000_000,
+            source=cursor["cost_source"], estimated_usd=estimated_component,
+        )
+
+        # spent_usd must still receive the FULL stage total.
+        assert state.budget.spent_usd == pytest.approx(20.50)
+        # estimated_usd must equal ONLY the estimated component ($18.00), NOT
+        # the mixed stage total ($20.50). This is the assertion that fails
+        # against the pre-fix code, which reads estimated_usd == 20.50 here.
+        assert state.budget.estimated_usd == pytest.approx(18.0)
+
+    def test_wholly_measured_stage_leaves_estimated_usd_at_zero(self) -> None:
+        cursor: dict = {"stage_id": "s2", "project_path": ".", "workflow_id": None}
+        gen_cost, _ = _priced_cost(cursor, {"cost_usd": 5.0}, label="generate")
+        judge_cost, _ = _priced_cost(cursor, {"cost_usd": 1.0}, label="judge")
+        estimated_component = float(cursor.get("estimated_cost_usd") or 0.0)
+        assert estimated_component == pytest.approx(0.0)
+
+        state = _state(budget=100.0)
+        charge_and_gate(
+            state, gen_cost + judge_cost, 0,
+            source=cursor["cost_source"], estimated_usd=estimated_component,
+        )
+        assert state.budget.spent_usd == pytest.approx(6.0)
+        assert state.budget.estimated_usd == pytest.approx(0.0)
+
+    def test_wholly_estimated_stage_has_estimated_usd_equal_spent_usd(self) -> None:
+        cursor: dict = {"stage_id": "s3", "project_path": ".", "workflow_id": None}
+        result = {"tokens_in": 1_000_000, "tokens_out": 1_000_000, "model": "claude-sonnet-5"}
+        gen_cost, _ = _priced_cost(cursor, result, label="generate")
+        estimated_component = float(cursor.get("estimated_cost_usd") or 0.0)
+
+        state = _state(budget=100.0)
+        charge_and_gate(
+            state, gen_cost, 2_000_000,
+            source=cursor["cost_source"], estimated_usd=estimated_component,
+        )
+        assert state.budget.spent_usd == pytest.approx(18.0)
+        assert state.budget.estimated_usd == pytest.approx(state.budget.spent_usd)

--- a/tests/test_fable_audit_2.py
+++ b/tests/test_fable_audit_2.py
@@ -1703,14 +1703,31 @@ class TestRiderBRecoverySafeOrdering:
         src = inspect.getsource(cli_mod._cmd_attended_submit)
         # Match the actual CALL sites, not the import at the top of the function.
         # mark_charged call: "mark_charged(cfile)"
-        # charge_and_gate call: "charge_and_gate(state, cost, toks)"
+        # charge_and_gate call: the "charge_and_gate(" invocation that follows
+        # mark_charged, keyed on "source=cost_source" appearing in the same
+        # call (not just the import statement further up).
+        # (B8: the source= kwarg was added so an unreporting host prices as
+        # estimated/unmeasured rather than free. Mixed-provenance fix: the
+        # call now also forwards estimated_usd=; the call site's SHAPE
+        # changed, but the ordering this test pins is unchanged.)
+        import re
         idx_mark = src.find("mark_charged(cfile)")
-        idx_charge = src.find("charge_and_gate(state, cost, toks)")
         assert idx_mark != -1, (
             "mark_charged(cfile) call must appear in _cmd_attended_submit"
         )
-        assert idx_charge != -1, (
-            "charge_and_gate(state, cost, toks) call must appear in _cmd_attended_submit"
+        # Match the real invocation ("charge_and_gate(state, ..." or
+        # "charge_and_gate(\n    state, ..."), not a bare "charge_and_gate(...)"
+        # mentioned in a nearby comment.
+        m = re.search(r"charge_and_gate\(\s*state\b", src[idx_mark:])
+        assert m is not None, (
+            "a charge_and_gate(state, ...) call must appear in "
+            "_cmd_attended_submit after mark_charged(cfile)"
+        )
+        idx_charge = idx_mark + m.start()
+        call_snippet = src[idx_charge:idx_charge + 200]
+        assert "source=cost_source" in call_snippet, (
+            "the post-mark_charged charge_and_gate(...) call must forward "
+            f"source=cost_source; got: {call_snippet!r}"
         )
         assert idx_mark < idx_charge, (
             f"Rider (b) recovery-safe ordering: mark_charged call (pos {idx_mark}) must "

--- a/tests/test_fable_audit_2.py
+++ b/tests/test_fable_audit_2.py
@@ -1717,17 +1717,43 @@ class TestRiderBRecoverySafeOrdering:
         )
         # Match the real invocation ("charge_and_gate(state, ..." or
         # "charge_and_gate(\n    state, ..."), not a bare "charge_and_gate(...)"
-        # mentioned in a nearby comment.
-        m = re.search(r"charge_and_gate\(\s*state\b", src[idx_mark:])
+        # mentioned in a nearby comment, and not the
+        # "from .governance import charge_and_gate" statement.
+        #
+        # IMPORTANT: search the WHOLE function source, not just the slice
+        # after idx_mark. Scoping the search to src[idx_mark:] made
+        # idx_charge = idx_mark + m.start() unconditionally >= idx_mark,
+        # so the later `assert idx_mark < idx_charge` ordering check could
+        # never fail even if the real call were moved before mark_charged.
+        # Searching the full source lets a reversed ordering actually
+        # produce idx_charge < idx_mark, so the ordering assertion below is
+        # the one that fires (not this "call must exist" assertion).
+        call_re = re.compile(r"charge_and_gate\(\s*state\b")
+        idx_charge = None
+        m = None
+        for cand in call_re.finditer(src):
+            # Skip mentions inside a comment (e.g. the ordering explainer
+            # comment block: "#   2. charge_and_gate(...)"). A commented
+            # mention never matches `charge_and_gate\(\s*state\b` anyway
+            # (comments here use "charge_and_gate(...)", not "(...state"),
+            # but guard explicitly so this stays true if the comment wording
+            # changes again.
+            line_start = src.rfind("\n", 0, cand.start()) + 1
+            line = src[line_start:cand.start()]
+            if line.lstrip().startswith("#"):
+                continue
+            m = cand
+            idx_charge = cand.start()
+            break
         assert m is not None, (
             "a charge_and_gate(state, ...) call must appear in "
-            "_cmd_attended_submit after mark_charged(cfile)"
+            "_cmd_attended_submit (excluding the import statement and any "
+            "comment mentions)"
         )
-        idx_charge = idx_mark + m.start()
         call_snippet = src[idx_charge:idx_charge + 200]
         assert "source=cost_source" in call_snippet, (
-            "the post-mark_charged charge_and_gate(...) call must forward "
-            f"source=cost_source; got: {call_snippet!r}"
+            "the charge_and_gate(...) call must forward source=cost_source; "
+            f"got: {call_snippet!r}"
         )
         assert idx_mark < idx_charge, (
             f"Rider (b) recovery-safe ordering: mark_charged call (pos {idx_mark}) must "

--- a/tests/test_transcript_cost.py
+++ b/tests/test_transcript_cost.py
@@ -1,0 +1,95 @@
+"""Part 5 — transcript_cost.summarize_transcript_cost.
+
+Sums + prices per-turn ``message.usage`` from a JSONL subagent transcript.
+Hermetic: writes only to tmp_path, no network.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hydra_core.transcript_cost import summarize_transcript_cost
+
+
+def _write_transcript(path: Path, lines: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(l) for l in lines), encoding="utf-8")
+
+
+def test_sums_and_prices_known_model_turns(tmp_path: Path) -> None:
+    path = tmp_path / "transcript.jsonl"
+    _write_transcript(path, [
+        {"message": {"model": "claude-sonnet-5",
+                     "usage": {"input_tokens": 500_000, "output_tokens": 500_000}}},
+        {"message": {"model": "claude-sonnet-5",
+                     "usage": {"input_tokens": 500_000, "output_tokens": 500_000}}},
+    ])
+    summary = summarize_transcript_cost(path)
+    assert summary.turns == 2
+    assert summary.tokens_in == 1_000_000
+    assert summary.tokens_out == 1_000_000
+    # Sonnet: $3/Mtok in + $15/Mtok out => $18.0 total across both turns.
+    assert summary.cost_usd == pytest.approx(18.0)
+    assert summary.fully_priced is True
+
+
+def test_unknown_model_tracked_as_unpriced_not_raised(tmp_path: Path) -> None:
+    # FALSIFIABILITY: without the `if priced is None: unpriced_models.add(...)`
+    # branch, an unknown model would either raise (price_call returning None
+    # and the caller doing `summary.cost_usd += None`) or silently drop the
+    # signal that the total is partial.
+    path = tmp_path / "transcript.jsonl"
+    _write_transcript(path, [
+        {"message": {"model": "unknown-model-abc",
+                     "usage": {"input_tokens": 1000, "output_tokens": 1000}}},
+    ])
+    summary = summarize_transcript_cost(path)
+    assert summary.turns == 1
+    assert summary.cost_usd == pytest.approx(0.0)
+    assert "unknown-model-abc" in summary.unpriced_models
+    assert summary.fully_priced is False
+
+
+def test_malformed_lines_are_skipped_not_raised(tmp_path: Path) -> None:
+    path = tmp_path / "transcript.jsonl"
+    path.write_text(
+        "not json\n"
+        + json.dumps({"message": {"model": "claude-sonnet-5",
+                                   "usage": {"input_tokens": 1000, "output_tokens": 1000}}})
+        + "\n{}\n",
+        encoding="utf-8",
+    )
+    summary = summarize_transcript_cost(path)
+    assert summary.turns == 1
+
+
+def test_missing_file_yields_zeroed_summary(tmp_path: Path) -> None:
+    summary = summarize_transcript_cost(tmp_path / "does-not-exist.jsonl")
+    assert summary.turns == 0
+    assert summary.cost_usd == 0.0
+
+
+def test_non_integer_token_values_do_not_raise(tmp_path: Path) -> None:
+    # FALSIFIABILITY: the pre-fix code did
+    # `int(usage.get("input_tokens") or 0)` with no type guard. A
+    # syntactically valid JSONL line whose token value is a string or a
+    # nested object raises TypeError/ValueError out of that bare `int(...)`
+    # call, contradicting this module's own docstring claim ("a corrupt or
+    # partial transcript must not crash the caller"). This line is valid
+    # JSON end to end — only the *value* of a token field is malformed.
+    path = tmp_path / "transcript.jsonl"
+    _write_transcript(path, [
+        # input_tokens is a numeric string -> should coerce to 500_000.
+        {"message": {"model": "claude-sonnet-5",
+                     "usage": {"input_tokens": "500000", "output_tokens": 500_000}}},
+        # output_tokens is a nested object -> unparseable, contributes 0.
+        {"message": {"model": "claude-sonnet-5",
+                     "usage": {"input_tokens": 500_000,
+                               "output_tokens": {"unexpected": "shape"}}}},
+    ])
+    summary = summarize_transcript_cost(path)  # must not raise
+    assert summary.turns == 2
+    assert summary.tokens_in == 1_000_000
+    assert summary.tokens_out == 500_000
+    assert summary.cost_usd == pytest.approx((3.0 * 1.0) + (15.0 * 0.5))


### PR DESCRIPTION
The engine treated a host result with no reported cost as free, so budget tripwires read a run's real spend as roughly zero. This makes the engine price the call itself and label where the number came from.

Design is the one approved earlier: estimate only, never block. No new human gate and no new block path. A stage that cannot be priced at all is logged and counts as zero rather than halting work.

## What changed

- **Cost provenance.** The cost recorder takes a source of measured, estimated or unmeasured, defaulting to measured so every existing caller is untouched. The budget ledger gains two companion counters.
- **Engine-side pricing.** A new module maps model ids to per-token rates, with an override file under the Hydra home directory. The environment variable is read at call time, not bound at import, so the hermetic suite can redirect it. An unknown model is not an error; it is unmeasured.
- **Log, never block.** An unpriceable stage increments a counter and emits a telemetry event.
- **Attended wiring.** The three accrual sites and the attempt records now route through the pricing path. The double-charge guard is untouched.
- **Host utility.** The transcript-summing technique is shipped as supported code so any host driving the workflow tools gets real numbers.

Measured and estimated dollars both accumulate into the spent total, so the 80 percent and 100 percent tripwires now see estimated money. That is the point. The estimate counter tracks only the estimated portion and never substitutes for the spent total.

## Two defects found, both the same shape

The recurring failure on this line of work is a test that passes without proving the property. Two more instances surfaced here.

**Caught before judging.** The first version's tripwire tests handed the ledger a dollar figure and then observed that a dollar figure moves the tripwire. Charging the same amount three ways, including the old call signature, gave identical results, so they proved nothing. A comment inside one claimed it would fail before this change, which was false. Both now derive the figure through the pricing path, and a new test carries an unreported result all the way into the budget gate. That join is what this change adds and it had no test at all.

**Caught by the judge, missed by me.** A stage collapses its cost sources into one label with estimated winning, and the charging site then booked the entire stage total under it. A stage with $2.50 measured and $18.00 estimated recorded $20.50 as estimated. The spend total and tripwires stayed correct, but the counter this change exists to provide was wrong on any mixed stage, which is the normal case: a measured generate followed by an estimated judge. Fixed by tracking the estimated dollars per component.

Verified invariants after the fix:

| Stage | spent | estimated | unmeasured |
|---|---|---|---|
| mixed | 20.5 | 18.0 | 0 |
| wholly measured | 2.5 | 0.0 | 0 |
| wholly estimated | 18.0 | 18.0 | 0 |
| unmeasured | 0.0 | 0.0 | 1 |

## Known wart

One pre-existing ordering test was rewritten twice as the call literal changed, and its closing comparison is now unreachable. I checked whether the guarantee survives by running the rewritten logic against synthetic sources: a swapped order still fails, on an earlier assertion. The property holds and the last line is dead. The judge agreed it is readability only. Worth a follow-up tidy.

## Evidence

Full suite in the main checkout: 1979 passed, 2 skipped, 0 failed.

Judged cross-vendor by codex. Round one returned revise on the mixed-provenance defect; the retry passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146EZPRzGWYGbmzMbV2naLe